### PR TITLE
Fixing an API removal from Crittercism's SDK.

### DIFF
--- a/Providers/CrittercismProvider.m
+++ b/Providers/CrittercismProvider.m
@@ -25,7 +25,7 @@
     }
 
     if (email) {
-        [Crittercism setEmail:email];
+        [self setUserProperty:@"email" toValue:email];
     }
 }
 


### PR DESCRIPTION
Not sure when this changed, but as of 4.1.1, `+setEmail:` doesn't exist. This should be backwards compatible with previous versions of Crittercism's SDK, but without knowing what happened when `+setEmail:` got called, I don't know if this is 100% accurate. Hopefully someone that's used `+setEmail:` can chime in?

This will close #32.
