### PR TITLE
GA dispatch with application lifecycle

### DIFF
--- a/ARAnalytics.podspec
+++ b/ARAnalytics.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name         =  'ARAnalytics'
-  s.version      =  '2.3.1'
+  s.version      =  '2.3.3'
   s.license      =  {:type => 'MIT', :file => 'LICENSE' }
   s.summary      =  'Use multiple major analytics platforms with one clean API.'
   s.homepage     =  'http://github.com/orta/ARAnalytics'

--- a/Providers/GoogleAnalyticsProvider.m
+++ b/Providers/GoogleAnalyticsProvider.m
@@ -13,7 +13,11 @@
 #import "GAIDictionaryBuilder.h"
 
 @interface GoogleAnalyticsProvider ()
-@property (nonatomic, strong) id<GAITracker> tracker;
+
+@property (nonatomic, strong) id <GAITracker> tracker;
+
+- (void) dispatchGA;
+
 @end
 
 @implementation GoogleAnalyticsProvider
@@ -21,9 +25,25 @@
 
 - (id)initWithIdentifier:(NSString *)identifier {
     NSAssert([GAI class], @"Google Analytics SDK is not included");
-    self.tracker = [[GAI sharedInstance] trackerWithTrackingId:identifier];
 
-    return [super init];
+    if ((self = [super init])) {
+        self.tracker = [[GAI sharedInstance] trackerWithTrackingId:identifier];
+
+        for( NSString *inactiveEvent in @[ UIApplicationWillResignActiveNotification,
+                                           UIApplicationWillTerminateNotification,
+                                           UIApplicationDidEnterBackgroundNotification ]) {
+            [[NSNotificationCenter defaultCenter] addObserver:self
+                                                     selector:@selector(dispatchGA)
+                                                         name:inactiveEvent
+                                                       object:nil];
+        }
+    }
+
+    return self;
+}
+
+- (void)dealloc {
+    [[NSNotificationCenter defaultCenter] removeObserver:self];
 }
 
 - (void)identifyUserWithID:(NSString *)userID andEmailAddress:(NSString *)email {
@@ -31,6 +51,8 @@
     // https://developers.google.com/analytics/devguides/collection/ios/v3/customdimsmets#pii
 
     // The Google Analytics Terms of Service prohibit sending of any personally identifiable information (PII) to Google Analytics servers. For more information, please consult the Terms of Service.
+
+    // Ideally we would put an assert here but if you have multiple providers that wouldn't make sense.
 }
 
 - (void)setUserProperty:(NSString *)property toValue:(NSString *)value {
@@ -58,6 +80,12 @@
                                                                               name:event
                                                                              label:nil];
     [self.tracker send:[builder build]];
+}
+
+#pragma mark - Dispatch
+
+- (void)dispatchGA {
+    [[GAI sharedInstance] dispatch];
 }
 
 #endif


### PR DESCRIPTION
Much like Localytics (#34), Google Analytics recommends dispatching in tandem with app lifecycle events. Added some!
