### PR TITLE
Crashlytics: set email instead of name

### DIFF
--- a/Providers/CrashlyticsProvider.h
+++ b/Providers/CrashlyticsProvider.h
@@ -17,6 +17,7 @@
 + (Crashlytics *)startWithAPIKey:(NSString *)apiKey;
 + (void)setUserIdentifier:(NSString *)identifier;
 + (void)setUserName:(NSString *)name;
++ (void)setUserEmail:(NSString *)email;
 + (void)setObjectValue:(id)value forKey:(NSString *)key;
 @end
 

--- a/Providers/CrashlyticsProvider.m
+++ b/Providers/CrashlyticsProvider.m
@@ -25,7 +25,7 @@
     }
 
     if (email) {
-        [Crashlytics setUserName:email];
+        [Crashlytics setUserEmail:email];
     }
 }
 


### PR DESCRIPTION
Crashlytics supports setting an email. http://support.crashlytics.com/knowledgebase/articles/92521-how-do-i-set-user-information-
