### PR TITLE
Bump deployment target to iOS6

### DIFF
--- a/ARAnalytics.podspec
+++ b/ARAnalytics.podspec
@@ -6,7 +6,7 @@ Pod::Spec.new do |s|
   s.homepage     =  'http://github.com/orta/ARAnalytics'
   s.authors      =  { 'orta' => 'orta.therox@gmail.com' }
   s.source       =  { :git => 'https://github.com/orta/ARAnalytics.git', :tag => s.version.to_s }
-  s.ios.deployment_target = "5.0"
+  s.ios.deployment_target = "6.0"
   s.requires_arc =  true
   s.summary      =  'Using subspecs you can define your analytics provider with the same API on iOS and OS X.'
   s.description  =  "ARAnalytics is a Cocoapods only library, which provides a sane API for tracking events and some simple user data. It currently supports for iOS: TestFlight, Mixpanel, Localytics, Flurry, Google Analytics, KISSMetrics, Tapstream, Countly, Crittercism, Bugsnag, Helpshift, Heap and Crashlytics. And for OS X: KISSmetrics, Countly and Mixpanel. It does this by using subspecs from CocoaPods 0.17+ to let you decide which libraries you'd like to use."


### PR DESCRIPTION
As iOS 7 released, there're some mobile analytics provider (e.g. Mixpanel) are moving their minimum iOS version support to iOS6, which results in some compatibility issue between `ARAnalytics` and those analytics SDKs.

`pod spec lint` would raise following errors:

```
[!] The platform of the target `Pods` (iOS 5.0) is not compatible with `Mixpanel (2.2.1)` which has a minimum requirement of iOS 6.0.
```
