### PR TITLE
Update HeapAnalytics dependency to official repository

### DIFF
--- a/ARAnalytics.podspec
+++ b/ARAnalytics.podspec
@@ -26,7 +26,7 @@ Pod::Spec.new do |s|
   amplitude      = { :spec_name => "Amplitude",        :dependency => "Amplitude-iOS" }
   hockeyApp      = { :spec_name => "HockeyApp",        :dependency => "HockeySDK" }
   parseAnalytics = { :spec_name => "ParseAnalytics",   :dependency => "Parse-iOS-SDK" }
-  heap           = { :spec_name => "HeapAnalytics",    :dependency => "HeapAnalytics" }
+  heap           = { :spec_name => "HeapAnalytics",    :dependency => "Heap" }
   chartbeat      = { :spec_name => "Chartbeat",        :dependency => "Chartbeat", :has_extension => true }
 
   crashlytics    = { :spec_name => "Crashlytics" }


### PR DESCRIPTION
The HeapAnalytics-Pod is unofficial and has been removed from the CocoaPods-listing. See:  https://github.com/CocoaPods/Specs/pull/6914
