### PR TITLE
Fixed build error with new Testflight SDK

### DIFF
--- a/Providers/TestFlightProvider.m
+++ b/Providers/TestFlightProvider.m
@@ -16,10 +16,7 @@
 
 - (id)initWithIdentifier:(NSString *)identifier {
     NSAssert([TestFlight class], @"TestFlight is not included");
-    // For non App store builds use a device identifier.
-#ifndef RELEASE
-    [TestFlight setDeviceIdentifier:[TestFlightProvider uniqueID]];
-#endif
+    
     [TestFlight takeOff:identifier];
 
     return [super init];


### PR DESCRIPTION
With the recent release of the Testflight SDK (2.2.3) 
- (void)setDeviceIdentifier:(NSString *)deviceIdentifer
  is no longer available.
  Using a + (void)takeOff instead should be fine.
