### PR TITLE
Added a method to record timing events with extra properties

### DIFF
--- a/ARAnalyticalProvider.h
+++ b/ARAnalyticalProvider.h
@@ -29,6 +29,10 @@
 /// Submit an event with a time interval
 - (void)logTimingEvent:(NSString *)event withInterval:(NSNumber *)interval;
 
+/// Submit an event with a time interval and extra properties
+/// @warning the properites must not contain the key string `length`.
+- (void)logTimingEvent:(NSString *)event withInterval:(NSNumber *)interval properties:(NSDictionary *)properties;
+
 /// Pass a specific event for showing a page
 - (void)didShowNewPageView:(NSString *)pageTitle;
 

--- a/ARAnalyticalProvider.m
+++ b/ARAnalyticalProvider.m
@@ -9,6 +9,8 @@
 #import <Foundation/Foundation.h>
 #import "ARAnalyticalProvider.h"
 
+static NSString *const ARTimingEventLengthKey = @"length";
+
 @implementation ARAnalyticalProvider
 
 - (id)initWithIdentifier:(NSString *)identifier {
@@ -39,7 +41,21 @@
 - (void)monitorNavigationViewController:(UINavigationController *)controller {}
 
 - (void)logTimingEvent:(NSString *)event withInterval:(NSNumber *)interval {
-    [self event:event withProperties:@{ @"length": interval }];
+    [self logTimingEvent:event withInterval:interval properties:nil];
+}
+
+- (void)logTimingEvent:(NSString *)event withInterval:(NSNumber *)interval properties:(NSDictionary *)properties {
+    
+    if (properties[ARTimingEventLengthKey]) {
+        NSString *warning = [NSString stringWithFormat:@"Properties for timing event '%@' contains a key that clashes with the key used for reporting the length: %@", event, ARTimingEventLengthKey];
+        NSLog(@"%@", warning);
+        NSAssert(properties[ARTimingEventLengthKey], @"%@", warning);
+    }
+    
+    NSMutableDictionary *mutableProperties = [NSMutableDictionary dictionaryWithDictionary:properties];
+    mutableProperties[ARTimingEventLengthKey] = interval;
+    
+    [self event:event withProperties:mutableProperties];
 }
 
 - (void)didShowNewPageView:(NSString *)pageTitle {

--- a/ARAnalytics.h
+++ b/ARAnalytics.h
@@ -112,6 +112,8 @@
 /// Let ARAnalytics deal with the timing of an event
 + (void)startTimingEvent:(NSString *)event;
 + (void)finishTimingEvent:(NSString *)event;
+/// @warning the properites must not contain the key string `length` .
++ (void)finishTimingEvent:(NSString *)event withProperties:(NSDictionary *)properties;
 
 @end
 

--- a/ARAnalytics.m
+++ b/ARAnalytics.m
@@ -379,6 +379,11 @@ static ARAnalytics *_sharedAnalytics;
 }
 
 + (void)finishTimingEvent:(NSString *)event {
+    [self finishTimingEvent:event withProperties:nil];
+}
+
++(void)finishTimingEvent:(NSString *)event withProperties:(NSDictionary *)properties {
+
     NSDate *startDate = _sharedAnalytics.eventsDictionary[event];
     if (!startDate) {
         NSLog(@"ARAnalytics: finish timing event called without a corrosponding start timing event");
@@ -389,7 +394,7 @@ static ARAnalytics *_sharedAnalytics;
     [_sharedAnalytics.eventsDictionary removeObjectForKey:event];
 
     [_sharedAnalytics iterateThroughProviders:^(ARAnalyticalProvider *provider) {
-        [provider logTimingEvent:event withInterval:@(eventInterval)];
+        [provider logTimingEvent:event withInterval:@(eventInterval) properties:properties];
     }];
 }
 


### PR DESCRIPTION
Hi,

I wanted to add properties to a timing event to basically measure what the user did over a session (for example number of games played during an app session).

The only issue I can see is that you might possible pass in a dictionary with a `length` key which would then clash with your `length` key you use for the event length.
I've overcome this by inn `DEBUG` this would crash alerting the programmer to the error, but in release the user set property would simply be overwritten and a `NSLog` outputted.

Cheers,

Rich
