### PR TITLE
Track Google analytic Timing Event

### DIFF
--- a/Providers/GoogleAnalyticsProvider.m
+++ b/Providers/GoogleAnalyticsProvider.m
@@ -84,8 +84,19 @@
     [self.tracker send:[[GAIDictionaryBuilder createAppView] build]];
 }
 
-- (void)logTimingEvent:(NSString *)event withInterval:(NSNumber *)interval {
-    [self event:event withProperties:@{ @"value": interval }];
+- (void)logTimingEvent:(NSString *)event withInterval:(NSNumber *)interval  properties:(NSDictionary *)properties{
+    // Prepare properties dictionary
+    if (!properties) {
+        properties = @{ @"value": @([interval intValue]) };
+    } else {
+        NSMutableDictionary *newProperties = [properties mutableCopy];
+        newProperties[@"value"] = @([interval intValue]);
+        properties = newProperties;
+    }
+    
+    // Send event
+    [self event:event withProperties:properties];
+    
     // By Google's header, the interval should be seconds in milliseconds.
     GAIDictionaryBuilder *builder = [GAIDictionaryBuilder createTimingWithCategory:@"default"
                                                                           interval:@((int)([interval doubleValue]*1000))


### PR DESCRIPTION
In the header `GAIDictionaryBuilder.h` of **Google Analytics iOS SDK v3**, it indicates that users should pass `intervalMillis` as time interval argument. (i.e. seconds in millisecond).
So this pull request first make the `interval` NSNumber object into double and multiplies 1000 to get milliseconds.

Second, the upstream implementation of `Providers/GoogleAnalyticsProvider.m` overrode wrong method when sending timing event.
In `+ [ARAnalytics finishTimingEvent:withProperties:]`, it calls `-[ARAnalyticalProvider logTimingEvent:withInterval:properties]`, but the `GoogleAnalyticsProvider.m` overrides `logTimingEvent:withInterval:`. This makes the implementation of `GoogleAnalyticsProvider` never called.
