### PR TITLE
aspectRef stored even on error

### DIFF
--- a/ARDSL.m
+++ b/ARDSL.m
@@ -83,8 +83,6 @@ static BOOL ar_shouldFireForInstance (NSDictionary *dictionary, id instance, NSA
         } else {
             [self storeAspectRef:aspectRef forClass:klass andSelector:selector];
         }
-
-        [self storeAspectRef:aspectRef forClass:klass andSelector:selector];
     }];
 }
 


### PR DESCRIPTION
Removed an additional call to `[self storeAspectRef:aspectRef forClass:klass andSelector:selector];`. The method was called even if there was an error hooking the selector.
