### PR TITLE
Logs the class name of the instance that caused the assertion to be fired

### DIFF
--- a/ARDSL.m
+++ b/ARDSL.m
@@ -112,7 +112,7 @@ static BOOL ar_shouldFireForInstance (NSDictionary *dictionary, id instance, NSA
                     pageName = dictionaryPageName;
                 } else {
                     pageName = [instance valueForKeyPath:pageNameKeypath];
-                    NSAssert(pageName, @"Value for Key on `%@` returned nil.", pageNameKeypath);
+                    NSAssert(pageName, @"Value for Key on `%@` returned nil from instance of class: `%@`", pageNameKeypath, NSStringFromClass([instance class]));
                 }
 
                 [ARAnalytics pageView:pageName];


### PR DESCRIPTION
More verbose logging: I added the class name of the instance that caused the assertion to be fired. 
It's IMO useful for an easier debugging.
