### PR TITLE
New Librato Provider

### DIFF
--- a/ARAnalytics.h
+++ b/ARAnalytics.h
@@ -88,7 +88,7 @@
 + (void)setupParseAnalyticsWithApplicationID:(NSString *)appID clientKey:(NSString *)clientKey;
 + (void)setupHeapAnalyticsWithApplicationID:(NSString *)appID;
 + (void)setupChartbeatWithApplicationID:(NSString *)appID;
-
++ (void)setupLibratoWithEmail:(NSString *)email token:(NSString *)token prefix:(NSString *)prefix;
 
 /// Add a provider manually
 + (void)setupProvider:(ARAnalyticalProvider *)provider;
@@ -182,3 +182,6 @@ extern const NSString *ARParseClientKey;
 extern const NSString *ARHeapAppID;
 extern const NSString *ARChartbeatID;
 extern const NSString *ARUMengAnalyticsID;
+extern const NSString *ARLibratoEmail;
+extern const NSString *ARLibratoToken;
+extern const NSString *ARLibratoPrefix;

--- a/ARAnalytics.m
+++ b/ARAnalytics.m
@@ -118,6 +118,10 @@ static ARAnalytics *_sharedAnalytics;
         [self setupUMengAnalyticsIDWithAppkey:analyticsDictionary[ARUMengAnalyticsID]];
     }
     
+    if (analyticsDictionary[ARLibratoEmail] && analyticsDictionary[ARLibratoToken]) {
+        [self setupLibratoWithEmail:analyticsDictionary[ARLibratoEmail] token:analyticsDictionary[ARLibratoToken] prefix:analyticsDictionary[ARLibratoPrefix]];
+    }
+
     // Crashlytics / Crittercism should stay at the bottom of this,
     // as they both need to register exceptions, and you'd only use one.
 
@@ -160,7 +164,9 @@ static ARAnalytics *_sharedAnalytics;
 }
 
 + (void)setupMixpanelWithToken:(NSString *)token {
+#ifdef AR_MIXPANEL_EXISTS
     [self setupMixpanelWithToken:token andHost:nil];
+#endif
 }
 
 + (void)setupMixpanelWithToken:(NSString *)token andHost:(NSString *)host {
@@ -295,7 +301,12 @@ static ARAnalytics *_sharedAnalytics;
 #endif
 }
 
-
++ (void)setupLibratoWithEmail:(NSString *)email token:(NSString *)token prefix:(NSString *)prefix {
+#ifdef AR_LIBRATO_EXISTS
+    LibratoProvider *provider = [[LibratoProvider alloc] initWithEmail:email token:token prefix:prefix];
+    [self setupProvider:provider];
+#endif
+}
 
 #pragma mark -
 #pragma mark User Setup
@@ -500,3 +511,6 @@ const NSString *ARParseClientKey = @"ARParseClientKey";
 const NSString *ARHeapAppID = @"ARHeapAppID";
 const NSString *ARChartbeatID = @"ARChartbeatID";
 const NSString *ARUMengAnalyticsID = @"ARUMengAnalyticsID";
+const NSString *ARLibratoEmail = @"ARLibratoEmail";
+const NSString *ARLibratoToken = @"ARLibratoToken";
+const NSString *ARLibratoPrefix = @"ARLibratoPrefix";

--- a/ARAnalytics.podspec
+++ b/ARAnalytics.podspec
@@ -31,14 +31,15 @@ Pod::Spec.new do |s|
   heap           = { :spec_name => "HeapAnalytics",    :dependency => "Heap" }
   chartbeat      = { :spec_name => "Chartbeat",        :dependency => "Chartbeat", :has_extension => true }
   umeng          = { :spec_name => "UMengAnalytics",   :dependency => "UMengAnalytics" }
-
+  
+  librato        = { :spec_name => "Librato" }
   crashlytics    = { :spec_name => "Crashlytics" }
 
   kissmetrics_mac = { :spec_name => "KISSmetricsOSX",  :dependency => "KISSmetrics",            :osx => true,  :provider => "KISSmetrics" }
 #  countly_mac     = { :spec_name => "CountlyOSX",      :dependency => "Countly",                :osx => true,  :provider => "Countly" }
   mixpanel_mac    = { :spec_name => "MixpanelOSX",     :dependency => "Mixpanel-OSX-Community", :osx => true,  :provider => "Mixpanel"}
 
-  $all_analytics = [testflight_sdk, mixpanel, localytics, flurry, google, kissmetrics, crittercism, crashlytics, bugsnag, countly, helpshift,kissmetrics_mac, mixpanel_mac, tapstream, newRelic, amplitude, hockeyApp, parseAnalytics, heap, chartbeat, umeng]
+  $all_analytics = [testflight_sdk, mixpanel, localytics, flurry, google, kissmetrics, crittercism, crashlytics, bugsnag, countly, helpshift,kissmetrics_mac, mixpanel_mac, tapstream, newRelic, amplitude, hockeyApp, parseAnalytics, heap, chartbeat, umeng, librato]
 
   # To make the pod spec API cleaner, subspecs are "iOS/KISSmetrics"
 

--- a/Providers/ARAnalyticsProviders.h
+++ b/Providers/ARAnalyticsProviders.h
@@ -82,3 +82,7 @@
 #ifdef AR_UMENGANALYTICS_EXISTS
 #import "UMengAnalyticsProvider.h"
 #endif
+
+#ifdef AR_LIBRATO_EXISTS
+#import "LibratoProvider.h"
+#endif

--- a/Providers/LibratoProvider.h
+++ b/Providers/LibratoProvider.h
@@ -1,0 +1,32 @@
+//
+//  LibratoProvider.h
+//  Pods
+//
+//  Created by Param Aggarwal on 24/07/2014.
+//
+//
+
+#import "ARAnalyticalProvider.h"
+
+// Whilst we do not include the Librato library
+// as it is not an official one
+// we can stub out the implementation with methods we want
+// so that it will link with the real framework later on ./
+#ifdef AR_LIBRATO_EXISTS
+
+@interface Librato : NSObject
+- (instancetype)initWithEmail:(NSString *)email token:(NSString *)apiKey prefix:(NSString *)prefix;
+- (void)add:(id)metrics;
+@end
+
+@interface LibratoMetric : NSObject
++ (instancetype)metricNamed:(NSString *)name valued:(NSNumber *)value;
+@end
+
+#endif
+
+@interface LibratoProvider : ARAnalyticalProvider
+
+- (instancetype)initWithEmail:(NSString *)email token:(NSString *)token prefix:(NSString *)prefix;
+
+@end

--- a/Providers/LibratoProvider.m
+++ b/Providers/LibratoProvider.m
@@ -1,0 +1,38 @@
+//
+//  LibratoProvider.m
+//  Pods
+//
+//  Created by Param Aggarwal on 24/07/2014.
+//
+//
+
+#import "LibratoProvider.h"
+
+@interface LibratoProvider ()
+
+@property Librato *client;
+
+@end
+
+@implementation LibratoProvider
+#ifdef AR_LIBRATO_EXISTS
+
+- (instancetype)initWithEmail:(NSString *)email token:(NSString *)token prefix:(NSString *)prefix {
+    NSAssert([Librato class], @"Librato is not included");
+    
+    self.client = [[Librato alloc] initWithEmail:email token:token prefix:prefix];
+    
+    return [super init];
+}
+
+- (void)logTimingEvent:(NSString *)event withInterval:(NSNumber *)interval properties:(NSDictionary *)properties {
+    
+    // convert metric to milliseconds
+    NSNumber *metricValue = [NSNumber numberWithInteger:roundf(interval.floatValue*1000)];
+    
+    LibratoMetric *metric = [LibratoMetric metricNamed:event valued:metricValue];
+    [self.client add:metric];
+}
+
+#endif
+@end


### PR DESCRIPTION
I have added a new Librato provider. Extremely useful for tracking all the metrics using the `startTimingEvent:` and `finishTimingEvent:` methods of ARAnalytics.

No other current integration seems to give better graphs for this. The code is verified and the data does show up on Librato. User needs to include the Librato iOS library just like we do for Crashlytics.
