### PR TITLE
Add provider instance access method

### DIFF
--- a/ARAnalytics.h
+++ b/ARAnalytics.h
@@ -109,6 +109,10 @@
 
 /// Show all current providers
 + (NSSet *)currentProviders;
+
+/// Get the instance of provider class which is setup ready.
+/// Developer must setup this provider ready via above methods and the argument must be a subclass of
+/// ARAnalyticalProvider or this methid returns nil.
 + (ARAnalyticalProvider *)providerInstanceOfClass:(Class)ProviderClass;
 
 /// Set a per user property

--- a/ARAnalytics.m
+++ b/ARAnalytics.m
@@ -158,11 +158,14 @@ static BOOL _ARLogShouldPrintStdout = YES;
 }
 
 + (ARAnalyticalProvider *)providerInstanceOfClass:(Class)ProviderClass {
+    // Check whether the ProviderClass is subclass of ARAnalyticalProvider or not
     if (![ProviderClass isSubclassOfClass:[ARAnalyticalProvider class]]) {
         return nil;
     }
+    // Find the instance by enumerating the providers set
     ARAnalyticalProvider *__block providerInstance = nil;
     [_sharedAnalytics.providers enumerateObjectsUsingBlock:^(id obj, BOOL *stop) {
+        // Get the proivder and return it
         if ((*stop = [obj isKindOfClass:ProviderClass])) {
             providerInstance = obj;
         }


### PR DESCRIPTION
For example, when developers use Google Analytics, they may have to get the instancde of `GoogleAnalyticsProvider` to setup `customDimensionMappings` property.
