### PR TITLE
Setting the user id (&uid) user property 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 * Stopped pinning to a specific Hockey version ( @orta )
 * Updated to use official Parse Pod ( thanks @kylef )
 * Added a getter for providers ( thanks @sodastsai )
+* Setting user id for Google Analytics ( thanks @glentregoning, @janj - Indiegogo)
 
 ## Version 2.8.0
 

--- a/Providers/GoogleAnalyticsProvider.m
+++ b/Providers/GoogleAnalyticsProvider.m
@@ -48,12 +48,13 @@
 }
 
 - (void)identifyUserWithID:(NSString *)userID andEmailAddress:(NSString *)email {
-    // Not allowed in GA
+    // The Google Analytics Terms of Service prohibit sending of any personally identifiable information (PII) to Google Analytics servers. For more information, please consult the Terms of Service.
     // https://developers.google.com/analytics/devguides/collection/ios/v3/customdimsmets#pii
 
-    // The Google Analytics Terms of Service prohibit sending of any personally identifiable information (PII) to Google Analytics servers. For more information, please consult the Terms of Service.
-
     // Ideally we would put an assert here but if you have multiple providers that wouldn't make sense.
+
+    // However setting of a User ID is allowed as per https://developers.google.com/analytics/devguides/collection/ios/v3/user-id .
+    [self setUserProperty:@"&uid" toValue:userID];
 }
 
 - (void)setUserProperty:(NSString *)property toValue:(NSString *)value {


### PR DESCRIPTION
Will set this on calls to [ARAnalytics identifyUserWithID:andEmailAddress:]
