### PR TITLE
Suppress undeclared selector warning

### DIFF
--- a/Providers/HockeyAppProvider.m
+++ b/Providers/HockeyAppProvider.m
@@ -56,8 +56,15 @@
 #pragma mark - BITUpdateManagerDelegate
 - (NSString *)customDeviceIdentifierForUpdateManager:(BITUpdateManager *)updateManager {
 #ifdef DEBUG
-    if ([[UIDevice currentDevice] respondsToSelector:@selector(uniqueIdentifier)])
+
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wundeclared-selector"
+
+    if ([[UIDevice currentDevice] respondsToSelector:@selector(uniqueIdentifier)]){
         return [[UIDevice currentDevice] performSelector:@selector(uniqueIdentifier)];
+    }
+#pragma clang diagnostic pop
+    
 #endif
     return nil;
 }


### PR DESCRIPTION
Xcode 6 returned these warnings:
Pods/ARAnalytics/Providers/HockeyAppProvider.m:59:55: Undeclared selector 'uniqueIdentifier'
