### PR TITLE
Adds provider for Branch.io

### DIFF
--- a/ARAnalytics.h
+++ b/ARAnalytics.h
@@ -75,6 +75,7 @@
 + (void)setupSwrveWithAppID:(NSString *)appID apiKey:(NSString *)apiKey;
 + (void)setupYandexMobileMetricaWithAPIKey:(NSString*)key;
 + (void)setupAdjustWithAppToken:(NSString *)token;
++ (void)setupBranchWithAPIKey:(NSString *)key;
 
 /// Add a provider manually
 + (void)setupProvider:(ARAnalyticalProvider *)provider;
@@ -182,4 +183,5 @@ extern const NSString *ARYandexMobileMetricaAPIKey;
 extern const NSString *ARAdjustAppTokenKey;
 extern const NSString *ARAppsFlyerAppID;
 extern const NSString *ARAppsFlyerDevKey;
+extern const NSString *ARBranchAPIKey;
 

--- a/ARAnalytics.m
+++ b/ARAnalytics.m
@@ -413,6 +413,13 @@ static BOOL _ARLogShouldPrintStdout = YES;
 #endif
 }
 
++ (void)setupBranchWithAPIKey:(NSString *)key {
+#ifdef AR_BRANCH_EXISTS
+    BranchProvider *provider = [[BranchProvider alloc] initWithAPIKey:key];
+    [self setupProvider:provider];
+#endif
+}
+
 #pragma mark -
 #pragma mark User Setup
 
@@ -645,4 +652,5 @@ const NSString *ARYandexMobileMetricaAPIKey = @"ARYandexMobileMetricaAPIKey";
 const NSString *ARAdjustAppTokenKey = @"ARAdjustAppTokenKey";
 const NSString *ARAppsFlyerAppID = @"ARAppsFlyerAppID";
 const NSString *ARAppsFlyerDevKey = @"ARAppsFlyerDevKey";
+const NSString *ARBranchAPIKey = @"ARBranchAPIKey";
                                       

--- a/ARAnalytics.podspec
+++ b/ARAnalytics.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name         =  'ARAnalytics'
-  s.version      =  '2.9.1'
+  s.version      =  '2.9.2'
   s.license      =  {:type => 'MIT', :file => 'LICENSE' }
   s.summary      =  'Use multiple major analytics platforms with one clean API.'
   s.homepage     =  'https://github.com/orta/ARAnalytics'
@@ -38,12 +38,13 @@ Pod::Spec.new do |s|
   testflight_sdk = { :spec_name => "TestFlight",          :dependency => ["TestFlightSDK", "BPXLUUIDHandler"] }
   crashlytics    = { :spec_name => "Crashlytics" }
   appsflyer      = { :spec_name => "AppsFlyer",           :dependency => "AppsFlyer-SDK" }
+  branch         = { :spec_name => "Branch"               :dependency => "Branch" }
 
   kissmetrics_mac = { :spec_name => "KISSmetricsOSX",  :dependency => "KISSmetrics",            :osx => true,  :provider => "KISSmetrics" }
 #  countly_mac     = { :spec_name => "CountlyOSX",      :dependency => "Countly",                :osx => true,  :provider => "Countly" }
   mixpanel_mac    = { :spec_name => "MixpanelOSX",     :dependency => "Mixpanel-OSX-Community", :osx => true,  :provider => "Mixpanel"}
 
-  $all_analytics = [testflight_sdk, mixpanel, localytics, flurry, google, kissmetrics, crittercism, crashlytics, bugsnag, countly, helpshift,kissmetrics_mac, mixpanel_mac, tapstream, newRelic, amplitude, hockeyApp, parseAnalytics, heap, chartbeat, umeng, librato, segmentio, swrve, yandex, adjust, appsflyer]
+  $all_analytics = [testflight_sdk, mixpanel, localytics, flurry, google, kissmetrics, crittercism, crashlytics, bugsnag, countly, helpshift,kissmetrics_mac, mixpanel_mac, tapstream, newRelic, amplitude, hockeyApp, parseAnalytics, heap, chartbeat, umeng, librato, segmentio, swrve, yandex, adjust, appsflyer, branch]
 
   # To make the pod spec API cleaner, subspecs are "iOS/KISSmetrics"
 

--- a/ARAnalytics.podspec
+++ b/ARAnalytics.podspec
@@ -38,7 +38,7 @@ Pod::Spec.new do |s|
   testflight_sdk = { :spec_name => "TestFlight",          :dependency => ["TestFlightSDK", "BPXLUUIDHandler"] }
   crashlytics    = { :spec_name => "Crashlytics" }
   appsflyer      = { :spec_name => "AppsFlyer",           :dependency => "AppsFlyer-SDK" }
-  branch         = { :spec_name => "Branch"               :dependency => "Branch" }
+  branch         = { :spec_name => "Branch",               :dependency => "Branch" }
 
   kissmetrics_mac = { :spec_name => "KISSmetricsOSX",  :dependency => "KISSmetrics",            :osx => true,  :provider => "KISSmetrics" }
 #  countly_mac     = { :spec_name => "CountlyOSX",      :dependency => "Countly",                :osx => true,  :provider => "Countly" }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
 * Added super properties that get sent with all event methods
 * Added support for AppsFlyer ( thanks @cdzombak )
 
+## Version 2.9.2
+
+* Added support for Branch.io ( thanks @scotthasbrouck )
+
 ## Version 2.9.0
 
 * Added Adjust provider ( thanks @ekurutepe )

--- a/Providers/ARAnalyticsProviders.h
+++ b/Providers/ARAnalyticsProviders.h
@@ -98,3 +98,7 @@
 #ifdef AR_APPSFLYER_EXISTS
 #import "AppsFlyerProvider.h"
 #endif
+
+#ifdef AR_BRANCH_EXISTS
+#import "BranchProvider.h"
+#endif

--- a/Providers/BranchProvider.h
+++ b/Providers/BranchProvider.h
@@ -1,0 +1,12 @@
+//
+//  BranchProvider.h
+//
+//
+
+#import "ARAnalyticalProvider.h"
+
+@interface Branch : ARAnalyticalProvider
+
+- (id)initWithAPIKey:(NSString *)key;
+
+@end

--- a/Providers/BranchProvider.h
+++ b/Providers/BranchProvider.h
@@ -5,7 +5,7 @@
 
 #import "ARAnalyticalProvider.h"
 
-@interface Branch : ARAnalyticalProvider
+@interface BranchProvider : ARAnalyticalProvider
 
 - (id)initWithAPIKey:(NSString *)key;
 

--- a/Providers/BranchProvider.m
+++ b/Providers/BranchProvider.m
@@ -1,0 +1,40 @@
+//
+//  BranchProvider.m
+//
+
+#import "BranchProvider.h"
+#import "ARAnalyticsProviders.h"
+#import "Branch.h"
+
+@implementation BranchProvider
+
+#ifdef AR_BRANCH_EXISTS
+- (id)initWithAPIKey:(NSString *)key {
+    NSAssert([Branch class], @"Branch is not included");
+    [Branch getInstance:apiKey];
+    return [super init];
+}
+
+- (void)identifyUserWithID:(NSString *)userID andEmailAddress:(NSString *)email {
+    if (!userID) return;
+    [[Branch getInstance] setIdentity:userID]; // Branch only takes a user id string, no email
+}
+
+- (void)event:(NSString *)event withProperties:(NSDictionary *)properties {
+    if (!event) return;
+    if (properties) {
+        [[Branch getInstance] userCompletedAction:event withState:properties];
+    } else {
+        [[Branch getInstance] userCompletedAction:event];
+    }
+}
+
+- (void)incrementUserProperty:(NSString *)counterName byInt:(NSNumber *)amount {
+    if (!counterName || !amount) return;
+    if ([counterName isEqualToString:@"redeem") {
+        [[Branch getInstance] redeemRewards:[amount intValue]];
+    }
+}
+
+#endif
+@end

--- a/Providers/BranchProvider.m
+++ b/Providers/BranchProvider.m
@@ -11,7 +11,7 @@
 #ifdef AR_BRANCH_EXISTS
 - (id)initWithAPIKey:(NSString *)key {
     NSAssert([Branch class], @"Branch is not included");
-    [Branch getInstance:apiKey];
+    [Branch getInstance:key];
     return [super init];
 }
 
@@ -31,7 +31,7 @@
 
 - (void)incrementUserProperty:(NSString *)counterName byInt:(NSNumber *)amount {
     if (!counterName || !amount) return;
-    if ([counterName isEqualToString:@"redeem") {
+    if ([counterName isEqualToString:@"redeem"]) {
         [[Branch getInstance] redeemRewards:[amount intValue]];
     }
 }

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ ARAnalytics v3.0.0 [![Build Status](https://travis-ci.org/orta/ARAnalytics.svg?b
 
 ARAnalytics is to iOS what [Analytical](https://github.com/jkrall/analytical) is to ruby, or [Analytics.js](http://segmentio.github.com/analytics.js/) is to javascript.
 
-ARAnalytics is a analytics abstraction library offering a sane API for tracking events and user data. It currently supports on iOS: TestFlight, Mixpanel, Localytics, Flurry, GoogleAnalytics, KISSmetrics, Crittercism, Crashlytics, Bugsnag, Countly, Helpshift, Tapstream, NewRelic, Amplitude, HockeyApp, ParseAnalytics, HeapAnalytics, Chartbeat and Yandex Mobile Metrica. And for OS X: KISSmetrics and Mixpanel. It does this by using CocoaPods subspecs to let you decide which libraries you'd like to use. You are free to also use the official API for any provider too. Also, comes with an amazing [DSL](#dsl) to clear up your methods.
+ARAnalytics is a analytics abstraction library offering a sane API for tracking events and user data. It currently supports on iOS: TestFlight, Mixpanel, Localytics, Flurry, GoogleAnalytics, KISSmetrics, Crittercism, Crashlytics, Bugsnag, Countly, Helpshift, Tapstream, NewRelic, Amplitude, HockeyApp, ParseAnalytics, HeapAnalytics, Chartbeat, Yandex Mobile Metrica, and Branch. And for OS X: KISSmetrics and Mixpanel. It does this by using CocoaPods subspecs to let you decide which libraries you'd like to use. You are free to also use the official API for any provider too. Also, comes with an amazing [DSL](#dsl) to clear up your methods.
 
 [Changelog](https://github.com/orta/ARAnalytics/blob/master/CHANGELOG.md)
 


### PR DESCRIPTION
I'm working with Branch.io (super easy way to pass deep link data through share links through app download and open). Here's an ARAnalytics provider for Branch that supports identifying users, registering events, and redeeming reward points.

Documentation for the Branch iOS SDK can be found on the Github repo:https://github.com/BranchMetrics/Branch-iOS-SDK

This PR includes a minor version bump, chagelog and readme updates, and the integration has been manually tested in an iOS app.