### PR TITLE
Migrate AdjustProvider to Adjust 4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 * Added super properties that get sent with all event methods
 * Added support for AppsFlyer ( thanks @cdzombak )
 * Added support for Branch.io ( thanks @scotthasbrouck )
+* Updated Adjust provider to support Adjust 4.0 ( thanks @HeEAaD )
 
 ## Version 2.9.0
 

--- a/Providers/AdjustProvider.m
+++ b/Providers/AdjustProvider.m
@@ -13,23 +13,33 @@
 
 - (id)initWithIdentifier:(NSString *)identifier {
     NSAssert([Adjust class], @"Adjust is not included");
-    [Adjust appDidLaunch:identifier];
-    
+
+    NSString *environment;
+    ADJConfig *adjustConfig;
+
 #if defined (DEBUG)
-    [Adjust setEnvironment:AIEnvironmentSandbox];
+    environment = ADJEnvironmentSandbox;
 #else
-    [Adjust setEnvironment:AIEnvironmentProduction];
+    environment = ADJEnvironmentProduction;
 #endif
-    
+
+    adjustConfig = [ADJConfig configWithAppToken:identifier
+                                     environment:environment];
+
+    [Adjust appDidLaunch:adjustConfig];
+
     return [super init];
 }
 
 - (void)event:(NSString *)event withProperties:(NSDictionary *)properties {
-    [Adjust trackEvent:event withParameters:properties];
+
+    ADJEvent *const adjustEvent = [ADJEvent eventWithEventToken:event];
+
+    [properties enumerateKeysAndObjectsUsingBlock:^(id key, id value, BOOL *stop) {
+        [adjustEvent addCallbackParameter:key value:value];
+    }];
+
+    [Adjust trackEvent:adjustEvent];
 }
-
-
-
-
 
 @end


### PR DESCRIPTION
Migrate AdjustProvider.m to Adjust 4.0 based on this migration guide: https://github.com/adjust/ios_sdk/blob/master/doc/migrate.md