### PR TITLE
excluding ARNavigationControllerDelegateProxy in osx builds

### DIFF
--- a/ARAnalytics.podspec
+++ b/ARAnalytics.podspec
@@ -49,7 +49,7 @@ Pod::Spec.new do |s|
 
   s.subspec "CoreMac" do |ss|
     ss.source_files = ['*.{h,m}', 'Providers/ARAnalyticalProvider.{h,m}', 'Providers/ARAnalyticsProviders.h']
-    ss.exclude_files = ['ARDSL.{h,m}']
+    ss.exclude_files = ['ARDSL.{h,m}', 'ARNavigationControllerDelegateProxy.{h,m}']
     ss.platform = :osx
   end
 


### PR DESCRIPTION
ARNavigationControllerDelegateProxy includes UIKit, and it should be excluded from osx builds.

Updated the podspec to exclude ARNavigationControllerDelegateProxy.h/m from osx builds.

See https://github.com/orta/ARAnalytics/issues/144