### PR TITLE
Chained progressive tracking

### DIFF
--- a/ARAnalytics.m
+++ b/ARAnalytics.m
@@ -1,6 +1,9 @@
 #import "ARAnalytics.h"
 #import "ARAnalyticalProvider.h"
 #import "ARAnalyticsProviders.h"
+#import "UIResponder+ARAnalytics.h"
+#import "UIApplication+ARAnalytics.h"
+#import "UIViewController+ARAnalytics.h"
 
 static ARAnalytics *_sharedAnalytics;
 static BOOL _ARLogShouldPrintStdout = YES;

--- a/ARAnalytics.m
+++ b/ARAnalytics.m
@@ -1,9 +1,6 @@
 #import "ARAnalytics.h"
 #import "ARAnalyticalProvider.h"
 #import "ARAnalyticsProviders.h"
-#import "UIResponder+ARAnalytics.h"
-#import "UIApplication+ARAnalytics.h"
-#import "UIViewController+ARAnalytics.h"
 
 static ARAnalytics *_sharedAnalytics;
 static BOOL _ARLogShouldPrintStdout = YES;
@@ -15,6 +12,9 @@ static BOOL _ARLogShouldPrintStdout = YES;
 @end
 
 #if TARGET_OS_IPHONE
+#import "UIResponder+ARAnalytics.h"
+#import "UIViewController+ARAnalytics.h"
+#import "UIApplication+ARAnalytics.h"
 #import "ARNavigationControllerDelegateProxy.h"
 @interface ARAnalytics ()
 {

--- a/ARAnalytics.podspec
+++ b/ARAnalytics.podspec
@@ -51,7 +51,7 @@ Pod::Spec.new do |s|
 
   s.subspec "CoreMac" do |ss|
     ss.source_files = ['*.{h,m}', 'Providers/ARAnalyticalProvider.{h,m}', 'Providers/ARAnalyticsProviders.h']
-    ss.exclude_files = ['ARDSL.{h,m}', 'ARNavigationControllerDelegateProxy.{h,m}', 'UI*+ARAnalytics.{h,m}']
+    ss.exclude_files = ['ARDSL.{h,m}', 'ARNavigationControllerDelegateProxy.{h,m}', 'UI*ARAnalytics.{h,m}']
     ss.platform = :osx
   end
 

--- a/ARAnalytics.podspec
+++ b/ARAnalytics.podspec
@@ -51,7 +51,7 @@ Pod::Spec.new do |s|
 
   s.subspec "CoreMac" do |ss|
     ss.source_files = ['*.{h,m}', 'Providers/ARAnalyticalProvider.{h,m}', 'Providers/ARAnalyticsProviders.h']
-    ss.exclude_files = ['ARDSL.{h,m}', 'ARNavigationControllerDelegateProxy.{h,m}']
+    ss.exclude_files = ['ARDSL.{h,m}', 'ARNavigationControllerDelegateProxy.{h,m}', 'UI*+ARAnalytics.{h,m}']
     ss.platform = :osx
   end
 

--- a/Bootstrap/Podfile.lock
+++ b/Bootstrap/Podfile.lock
@@ -1,25 +1,27 @@
 PODS:
-  - ARAnalytics/CoreIOS (3.0.0)
-  - ARAnalytics/DSL (3.0.0):
+  - ARAnalytics/CoreIOS (3.2.0)
+  - ARAnalytics/DSL (3.2.0):
     - ReactiveCocoa (~> 2.0)
     - RSSwizzle (~> 0.1.0)
-  - ARAnalytics/Mixpanel (3.0.0):
+  - ARAnalytics/Mixpanel (3.2.0):
     - ARAnalytics/CoreIOS
     - Mixpanel
-  - Expecta (0.3.2)
-  - Mixpanel (2.7.2):
-    - Mixpanel/MPCategoryHelpers (= 2.7.2)
-  - Mixpanel/MPCategoryHelpers (2.7.2)
+  - Expecta (0.4.2)
+  - Mixpanel (2.8.1):
+    - Mixpanel/Mixpanel (= 2.8.1)
+  - Mixpanel/Mixpanel (2.8.1):
+    - Mixpanel/MPCategoryHelpers
+  - Mixpanel/MPCategoryHelpers (2.8.1)
   - OCMock (2.2.4)
-  - ReactiveCocoa (2.3):
-    - ReactiveCocoa/UI (= 2.3)
-  - ReactiveCocoa/Core (2.3):
+  - ReactiveCocoa (2.5):
+    - ReactiveCocoa/UI (= 2.5)
+  - ReactiveCocoa/Core (2.5):
     - ReactiveCocoa/no-arc
-  - ReactiveCocoa/no-arc (2.3)
-  - ReactiveCocoa/UI (2.3):
+  - ReactiveCocoa/no-arc (2.5)
+  - ReactiveCocoa/UI (2.5):
     - ReactiveCocoa/Core
   - RSSwizzle (0.1.0)
-  - Specta (0.4.0)
+  - Specta (0.5.0)
 
 DEPENDENCIES:
   - ARAnalytics/DSL (from `../`)
@@ -30,15 +32,15 @@ DEPENDENCIES:
 
 EXTERNAL SOURCES:
   ARAnalytics:
-    :path: "../"
+    :path: ../
 
 SPEC CHECKSUMS:
-  ARAnalytics: c331321fc6b034ad6249cd43e226d0b262436ce5
-  Expecta: 8c507baf13211207b1e9d0a741480600e6b4ed15
-  Mixpanel: e9bcb16eb0e2a98fc330ceeb0d8b7f4aec4182ab
+  ARAnalytics: 2783c11c387c5047e96f00e5feaf4f0bd341839c
+  Expecta: 78b4e8b0c8291fa4524d7f74016b6065c2e391ec
+  Mixpanel: 93c4825025e6380ced273ed7178496282e385077
   OCMock: a6a7dc0e3997fb9f35d99f72528698ebf60d64f2
-  ReactiveCocoa: fbe689fe218063b7bbed41032912c9ca4fdbe172
+  ReactiveCocoa: e2db045570aa97c695e7aa97c2bcab222ae51f4a
   RSSwizzle: d561958f595028bfcef98c7d55c318b3878a61c6
-  Specta: a353759f073ffcc0a365b782fe4aaeac064c03c6
+  Specta: eb90708ed77569bbda089f8ead10bb99b8e9489e
 
-COCOAPODS: 0.37.0
+COCOAPODS: 0.37.1

--- a/README.md
+++ b/README.md
@@ -150,7 +150,7 @@ Starting with HockeyApp version 3.7.0, the HockeyApp provider will automatically
 ResponderChain
 ----
 
-By calling `-trackEvent:withProperties:` on a UIResponder subclass it's possible to send an event down the responder chain and with that capture data to be tracked. To add more data along the chain just override the same method and add values to the `properties` dictionary.
+By calling `-trackEvent:withProperties:` on a UIResponder subclass it's possible to send an event down the responder chain and with that capture data to be tracked. To add more data along the chain just override the same method and add values to the `properties` dictionary. An example of this can be found on `UIViewController+ARAnalytics` category.
 By default, the first view controller in the chain will add the property `screen` to the `properties` dictionary with its class name. This can be customized by overriding the method `-screenNameForTracking` on any `UIViewController` subclass. By returning nil on this method it's possible to avoid this behavior.
 
 Contributing

--- a/README.md
+++ b/README.md
@@ -147,6 +147,12 @@ HockeyApp
 
 Starting with HockeyApp version 3.7.0, the HockeyApp provider will automatically keep logs of events and include those in crash reports, thus adding ‘breadcrumbs’ to your report and hopefully providing helpful context for your crasp reports. Any messages logged with `ARLog()` will also get included in the report.
 
+ResponderChain
+----
+
+By calling `-trackEvent:withProperties:` on a UIResponder subclass it's possible to send an event down the responder chain and with that capture data to be tracked. To add more data along the chain just override the same method and add values to the `properties` dictionary.
+By default, the first view controller in the chain will add the property `screen` to the `properties` dictionary with its class name. This can be customized by overriding the method `-screenNameForTracking` on any `UIViewController` subclass. By returning nil on this method it's possible to avoid this behavior.
+
 Contributing
 ====
 See [Contributing](https://github.com/orta/ARAnalytics/blob/master/CONTRIBUTING.md)

--- a/UIApplication+ARAnalytics.h
+++ b/UIApplication+ARAnalytics.h
@@ -1,0 +1,5 @@
+#import <UIKit/UIKit.h>
+
+@interface UIApplication (ARAnalytics)
+
+@end

--- a/UIApplication+ARAnalytics.m
+++ b/UIApplication+ARAnalytics.m
@@ -1,0 +1,10 @@
+#import "UIApplication+ARAnalytics.h"
+
+#import "ARAnalytics.h"
+@implementation UIApplication (ARAnalytics)
+
+- (void)trackEvent:(NSString *)event withProperties:(NSDictionary *)properties {
+    [ARAnalytics event:event withProperties:properties];
+}
+
+@end

--- a/UIResponder+ARAnalytics.h
+++ b/UIResponder+ARAnalytics.h
@@ -1,0 +1,5 @@
+#import <UIKit/UIKit.h>
+
+@interface UIResponder (ARAnalytics)
+- (void)trackEvent:(NSString *)event withProperties:(NSDictionary *)properties;
+@end

--- a/UIResponder+ARAnalytics.m
+++ b/UIResponder+ARAnalytics.m
@@ -1,0 +1,9 @@
+#import "UIResponder+ARAnalytics.h"
+
+@implementation UIResponder (ARAnalytics)
+
+- (void)trackEvent:(NSString *)event withProperties:(NSDictionary *)properties {
+    [self.nextResponder trackEvent:event withProperties:properties];
+}
+
+@end

--- a/UIViewController+ARAnalytics.h
+++ b/UIViewController+ARAnalytics.h
@@ -1,6 +1,6 @@
 #import <UIKit/UIKit.h>
 
-FOUNDATION_EXPORT NSString *const kAKTrackingEventScreenKey;
+FOUNDATION_EXPORT NSString *const kARAnalyticsEventScreenKey;
 @interface UIViewController (ARAnalytics)
 - (NSString *)screenNameForTracking;
 @end

--- a/UIViewController+ARAnalytics.h
+++ b/UIViewController+ARAnalytics.h
@@ -1,0 +1,6 @@
+#import <UIKit/UIKit.h>
+
+FOUNDATION_EXPORT NSString *const kAKTrackingEventScreenKey;
+@interface UIViewController (ARAnalytics)
+- (NSString *)screenNameForTracking;
+@end

--- a/UIViewController+ARAnalytics.m
+++ b/UIViewController+ARAnalytics.m
@@ -1,6 +1,6 @@
 #import "UIViewController+ARAnalytics.h"
 
-NSString *const kAKTrackingEventScreenKey = @"screen";
+NSString *const kARAnalyticsEventScreenKey = @"screen";
 
 @implementation UIViewController (ARAnalytics)
 
@@ -11,10 +11,10 @@ NSString *const kAKTrackingEventScreenKey = @"screen";
 - (void)trackEvent:(NSString *)event withProperties:(NSDictionary *)properties {
     NSMutableDictionary *mutableProperties = [NSMutableDictionary dictionaryWithDictionary:properties];
     
-    if (!mutableProperties[kAKTrackingEventScreenKey]) {
+    if (!mutableProperties[kARAnalyticsEventScreenKey]) {
         NSString *screenName = [self screenNameForTracking];
         if (screenName.length > 0) {
-            mutableProperties[kAKTrackingEventScreenKey] = screenName;
+            mutableProperties[kARAnalyticsEventScreenKey] = screenName;
         }
     }
     

--- a/UIViewController+ARAnalytics.m
+++ b/UIViewController+ARAnalytics.m
@@ -1,10 +1,8 @@
 #import "UIViewController+ARAnalytics.h"
 
-NSString *const kARAnalyticsEventScreenKey = @"screen";
+#import "UIResponder+ARAnalytics.h"
 
-@interface UIResponder ()
-- (void)trackEvent:(NSString *)event withProperties:(NSDictionary *)properties;
-@end
+NSString *const kARAnalyticsEventScreenKey = @"screen";
 
 @implementation UIViewController (ARAnalytics)
 

--- a/UIViewController+ARAnalytics.m
+++ b/UIViewController+ARAnalytics.m
@@ -1,0 +1,21 @@
+#import "UIViewController+ARAnalytics.h"
+
+NSString *const kAKTrackingEventScreenKey = @"screen";
+
+@implementation UIViewController (ARAnalytics)
+
+- (NSString *)screenNameForTracking {
+    return NSStringFromClass(self.class);
+}
+
+- (void)trackEvent:(NSString *)event withProperties:(NSDictionary *)properties {
+    NSMutableDictionary *mutableProperties = [NSMutableDictionary dictionaryWithDictionary:properties];
+    
+    if (!mutableProperties[kAKTrackingEventScreenKey]) {
+        mutableProperties[kAKTrackingEventScreenKey] = [self screenNameForTracking];
+    }
+    
+    [super trackEvent:event withProperties:mutableProperties];
+}
+
+@end

--- a/UIViewController+ARAnalytics.m
+++ b/UIViewController+ARAnalytics.m
@@ -1,8 +1,10 @@
 #import "UIViewController+ARAnalytics.h"
 
-#import "UIResponder+ARAnalytics.h"
-
 NSString *const kARAnalyticsEventScreenKey = @"screen";
+
+@interface UIResponder ()
+- (void)trackEvent:(NSString *)event withProperties:(NSDictionary *)properties;
+@end
 
 @implementation UIViewController (ARAnalytics)
 

--- a/UIViewController+ARAnalytics.m
+++ b/UIViewController+ARAnalytics.m
@@ -12,7 +12,10 @@ NSString *const kAKTrackingEventScreenKey = @"screen";
     NSMutableDictionary *mutableProperties = [NSMutableDictionary dictionaryWithDictionary:properties];
     
     if (!mutableProperties[kAKTrackingEventScreenKey]) {
-        mutableProperties[kAKTrackingEventScreenKey] = [self screenNameForTracking];
+        NSString *screenName = [self screenNameForTracking];
+        if (screenName.length > 0) {
+            mutableProperties[kAKTrackingEventScreenKey] = screenName;
+        }
     }
     
     [super trackEvent:event withProperties:mutableProperties];


### PR DESCRIPTION
Using the responder chain to progressively adding properties to an event.
Events can be sent down the chain by calling -trackEvent:withProperties: on any UIResponder subclass.
UIApplication will find these events and send it to ARAnalytics.
Any UIResponder subclass can override that method to add properties for themselves. This allows adding context to an event without having to have it promptly where the event if initially fired.