### PR TITLE
Fix fabric.io provider setup fix

### DIFF
--- a/ARAnalytics.h
+++ b/ARAnalytics.h
@@ -51,7 +51,7 @@
 /// Setup methods for each individual analytics providers
 + (void)setupTestFlightWithAppToken:(NSString *)token;
 + (void)setupCrashlyticsWithAPIKey:(NSString *)key;
-+ (void)setupFabricWithKits:(NSDictionary *)kits;
++ (void)setupFabricWithKits:(NSArray *)kits;
 + (void)setupMixpanelWithToken:(NSString *)token;
 + (void)setupMixpanelWithToken:(NSString *)token andHost:(NSString *)host;
 + (void)setupFlurryWithAPIKey:(NSString *)key;

--- a/ARAnalytics.m
+++ b/ARAnalytics.m
@@ -218,7 +218,7 @@ static BOOL _ARLogShouldPrintStdout = YES;
 #endif
 }
 
-+ (void)setupFabricWithKits:(NSDictionary *)kits
++ (void)setupFabricWithKits:(NSArray *)kits
 {
 #ifdef AR_FABRIC_EXISTS
     FabricProvider *provider = [[FabricProvider alloc] initWithKits:kits];

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Version 3.3.0
 
 * Added support for extra properties on screen views ( @alloy )
+* Corrected interface of `+[ARAnalytics setupFabricWithKits:]`. (from NSDictionary to NSArray) ( @sodastsai )
 
 ## Version 3.2.0
 


### PR DESCRIPTION
The `FabricProvider` and `Fabric` itself uses an `NSArray` as initializer arguments. But the `ARAnalytics` uses an in-corresponding type. (NSDictionary)