### PR TITLE
Mixpanel timing

### DIFF
--- a/ARAnalyticalProvider.m
+++ b/ARAnalyticalProvider.m
@@ -56,7 +56,9 @@ static NSString *const ARTimingEventLengthKey = @"length";
     }
     
     NSMutableDictionary *mutableProperties = [NSMutableDictionary dictionaryWithDictionary:properties];
-    mutableProperties[ARTimingEventLengthKey] = interval;
+    if (interval) {
+        mutableProperties[ARTimingEventLengthKey] = interval;
+    }
     
     [self event:event withProperties:mutableProperties];
 }

--- a/Providers/MixpanelProvider.m
+++ b/Providers/MixpanelProvider.m
@@ -2,6 +2,8 @@
 #import "ARAnalyticsProviders.h"
 #import "Mixpanel.h"
 
+static NSString * const kMixpanelTimingPropertyKey = @"$duration";
+
 @implementation MixpanelProvider
 
 - (id)initWithIdentifier:(NSString *)identifier {
@@ -42,6 +44,22 @@
 
 - (void)event:(NSString *)event withProperties:(NSDictionary *)properties {
     [[Mixpanel sharedInstance] track:event properties:properties];
+}
+
+- (void)logTimingEvent:(NSString *)event withInterval:(NSNumber *)interval properties:(NSDictionary *)properties {
+    
+    if (properties[kMixpanelTimingPropertyKey]) {
+        NSString *warning = [NSString stringWithFormat:@"Properties for timing event '%@' contains a key that clashes with the key used for reporting the time: %@", event, kMixpanelTimingPropertyKey];
+        NSLog(@"%@", warning);
+        NSAssert(properties[kMixpanelTimingPropertyKey], @"%@", warning);
+    }
+    
+    NSMutableDictionary *mutableProperties = [NSMutableDictionary dictionaryWithDictionary:properties];
+    if (interval) {
+        mutableProperties[kMixpanelTimingPropertyKey] = interval;
+    }
+    
+    [self event:event withProperties:mutableProperties];
 }
 
 #endif


### PR DESCRIPTION
Providing implementation of timing for Mixpanel.

Specifically, overrode `logTimingEvent:withInterval:properties:` to provide the timing property with key "$duration" as expected by Mixpanel 2.8.1.