### PR TITLE
Fix breadcrumbs in Release builds.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # ARAnalytics
 
+## Version 3.6.1
+
+* Fixed breadcrumb logging in builds with `NS_BLOCK_ASSERTIONS` enabled ( @alloy )
+
 ## Version 3.6.0
 
 * Added support for Hockey's new Source subspec and OS X library ( @jhersh )

--- a/Example/ARAnalyticsTests.xcodeproj/xcshareddata/xcschemes/ARAnalyticsBootstrapiOS.xcscheme
+++ b/Example/ARAnalyticsTests.xcodeproj/xcshareddata/xcschemes/ARAnalyticsBootstrapiOS.xcscheme
@@ -58,7 +58,8 @@
       ignoresPersistentStateOnLaunch = "NO"
       debugDocumentVersioning = "YES"
       allowLocationSimulation = "YES">
-      <BuildableProductRunnable>
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
          <BuildableReference
             BuildableIdentifier = "primary"
             BlueprintIdentifier = "60A5E60C1698DB4400686918"
@@ -76,7 +77,8 @@
       useCustomWorkingDirectory = "NO"
       buildConfiguration = "Release"
       debugDocumentVersioning = "YES">
-      <BuildableProductRunnable>
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
          <BuildableReference
             BuildableIdentifier = "primary"
             BlueprintIdentifier = "60A5E60C1698DB4400686918"
@@ -87,7 +89,7 @@
       </BuildableProductRunnable>
    </ProfileAction>
    <AnalyzeAction
-      buildConfiguration = "Debug">
+      buildConfiguration = "Release">
    </AnalyzeAction>
    <ArchiveAction
       buildConfiguration = "Release"

--- a/README.md
+++ b/README.md
@@ -146,6 +146,8 @@ HockeyApp
 
 Starting with HockeyApp version 3.7.0, the HockeyApp provider will automatically keep logs of events and include those in crash reports, thus adding ‘breadcrumbs’ to your report and hopefully providing helpful context for your crash reports. Any messages logged with `ARLog()` will also get included in the report.
 
+Note, however, that on iOS `syslogd` will not keep logs around for a long time, as such you should only expect logs of people that re-start the application immediately after the application crashing.
+
 
 Full list of subspecs
 ----


### PR DESCRIPTION
Specifically builds that define `NS_BLOCK_ASSERTIONS`. That was a silly mistake.

![](http://media4.giphy.com/media/OTQcSHJ9oBlYI/giphy.gif)

Fixes #166.