### PR TITLE
Fix Keen sharedClient method signature

### DIFF
--- a/Providers/KeenProvider.m
+++ b/Providers/KeenProvider.m
@@ -11,7 +11,7 @@ static NSString * const kKeenEmailKey = @"email";
 - (instancetype)initWithProjectID:(NSString *)projectID andWriteKey:(NSString *)writeKey andReadKey:(NSString *)readKey {
 #ifdef AR_KEEN_EXISTS
     NSAssert([KeenClient class], @"Keen Client is not included");
-    [KeenClient sharedClientWithProjectId:projectID andWriteKey:writeKey andReadKey:readKey];
+    [KeenClient sharedClientWithProjectID:projectID andWriteKey:writeKey andReadKey:readKey];
 #endif
     return [super init];
 }


### PR DESCRIPTION
Small patch, looks like Keen SDK method signature changed, so the project didn't compile if you had `Keen` subspec installed. This PR fixes the issue.

P.S. Thanks for the project @orta :+1: 