### PR TITLE
Show event name in finishTimingEvent warning

### DIFF
--- a/ARAnalytics.m
+++ b/ARAnalytics.m
@@ -651,7 +651,7 @@ static BOOL _ARLogShouldPrintStdout = YES;
 {
     NSDate *startDate = _sharedAnalytics.eventsDictionary[event];
     if (!startDate) {
-        NSLog(@"ARAnalytics: finish timing event called without a corrosponding start timing event");
+        NSLog(@"ARAnalytics: finish timing event (%@) called without a corrosponding start timing event", event);
         return;
     }
 


### PR DESCRIPTION
Another quick fix. I found it useful to see actual event name in `finishTimingEvent` method warning so I can track down the problem easily. :bug: 