### PR TITLE
Crashlytics/Fabric enhancement

### DIFF
--- a/ARAnalytics.podspec
+++ b/ARAnalytics.podspec
@@ -36,8 +36,8 @@ Pod::Spec.new do |s|
   adjust         = { :spec_name => "Adjust",              :dependency => "Adjust" }
   intercom       = { :spec_name => "Intercom",            :dependency => "Intercom" }
   librato        = { :spec_name => "Librato" }
-  crashlytics    = { :spec_name => "Crashlytics" }
-  fabric         = { :spec_name => "Fabric" }
+  crashlytics    = { :spec_name => "Crashlytics",         :dependency => "Crashlytics" }
+  fabric         = { :spec_name => "Fabric",              :dependency => ["Fabric", "Crashlytics"] }
   appsflyer      = { :spec_name => "AppsFlyer",           :dependency => "AppsFlyer-SDK" }
   branch         = { :spec_name => "Branch",              :dependency => "Branch" }
   snowplow       = { :spec_name => "Snowplow",            :dependency => "SnowplowTracker" }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # ARAnalytics
 
+## Version 3.6.4
+
+* Replace class method calls of Crashlytics by calls to `sharedInstances` (class methods are deprecated) ( @sodastsai )
+* Add dependencies to Crashlytics and Fabric to their providers. ( @sodastsai )
+
 ## Version 3.6.3
 
 * Implement `didShowNewPageView:withProperties:` correctly (Google Analytics) ( @sodastsai )

--- a/Providers/CrashlyticsProvider.h
+++ b/Providers/CrashlyticsProvider.h
@@ -7,10 +7,11 @@
 
 @interface Crashlytics : NSObject
 + (Crashlytics *)startWithAPIKey:(NSString *)apiKey;
-+ (void)setUserIdentifier:(NSString *)identifier;
-+ (void)setUserName:(NSString *)name;
-+ (void)setUserEmail:(NSString *)email;
-+ (void)setObjectValue:(id)value forKey:(NSString *)key;
++ (Crashlytics *)sharedInstance;
+- (void)setUserIdentifier:(NSString *)identifier;
+- (void)setUserName:(NSString *)name;
+- (void)setUserEmail:(NSString *)email;
+- (void)setObjectValue:(id)value forKey:(NSString *)key;
 @end
 
 OBJC_EXTERN void CLSLog(NSString *format, ...) NS_FORMAT_FUNCTION(1,2);

--- a/Providers/CrashlyticsProvider.m
+++ b/Providers/CrashlyticsProvider.m
@@ -13,16 +13,16 @@
 
 - (void)identifyUserWithID:(NSString *)userID andEmailAddress:(NSString *)email {
     if (userID) {
-        [Crashlytics setUserIdentifier:userID];
+        [[Crashlytics sharedInstance] setUserIdentifier:userID];
     }
 
     if (email) {
-        [Crashlytics setUserEmail:email];
+        [[Crashlytics sharedInstance] setUserEmail:email];
     }
 }
 
 - (void)setUserProperty:(NSString *)property toValue:(NSString *)value {
-    [Crashlytics setObjectValue:value forKey:property];
+    [[Crashlytics sharedInstance] setObjectValue:value forKey:property];
 }
 
 - (void)event:(NSString *)event withProperties:(NSDictionary *)properties {
@@ -32,7 +32,7 @@
     } else {
         log = event;
     }
-    
+
     CLSLog(@"%@", log);
 }
 

--- a/Providers/FabricProvider.m
+++ b/Providers/FabricProvider.m
@@ -1,10 +1,11 @@
 #import "FabricProvider.h"
 
 @interface Crashlytics : NSObject
-+ (void)setUserIdentifier:(NSString *)identifier;
-+ (void)setUserName:(NSString *)name;
-+ (void)setUserEmail:(NSString *)email;
-+ (void)setObjectValue:(id)value forKey:(NSString *)key;
++ (Crashlytics *)sharedInstance;
+- (void)setUserIdentifier:(NSString *)identifier;
+- (void)setUserName:(NSString *)name;
+- (void)setUserEmail:(NSString *)email;
+- (void)setObjectValue:(id)value forKey:(NSString *)key;
 @end
 
 @implementation FabricProvider
@@ -28,16 +29,16 @@
 
 - (void)identifyUserWithID:(NSString *)userID andEmailAddress:(NSString *)email {
     if (userID) {
-        [Crashlytics setUserIdentifier:userID];
+        [[Crashlytics sharedInstance] setUserIdentifier:userID];
     }
 
     if (email) {
-        [Crashlytics setUserEmail:email];
+        [[Crashlytics sharedInstance] setUserEmail:email];
     }
 }
 
 - (void)setUserProperty:(NSString *)property toValue:(NSString *)value {
-    [Crashlytics setObjectValue:value forKey:property];
+    [[Crashlytics sharedInstance] setObjectValue:value forKey:property];
 }
 
 - (void)event:(NSString *)event withProperties:(NSDictionary *)properties {


### PR DESCRIPTION
1. Replace deprecated API usage
2. Add dependencies (The `Fabric` and `Crashlytics` are official podspecs now.)