### PR TITLE
Don't use a Singleton for the MixpanelProvider.

### DIFF
--- a/Providers/MixpanelProvider.h
+++ b/Providers/MixpanelProvider.h
@@ -2,4 +2,5 @@
 
 @interface MixpanelProvider : ARAnalyticalProvider
 - (id)initWithIdentifier:(NSString *)identifier andHost:(NSString *)host;
+- (void)createAlias:(NSString *)alias;
 @end

--- a/Providers/MixpanelProvider.m
+++ b/Providers/MixpanelProvider.m
@@ -4,6 +4,10 @@
 
 static NSString * const kMixpanelTimingPropertyKey = @"$duration";
 
+@interface MixpanelProvider()
+    @property (nonatomic, readonly) Mixpanel *mixpanel;
+@end
+
 @implementation MixpanelProvider
 
 - (id)initWithIdentifier:(NSString *)identifier {
@@ -14,10 +18,10 @@ static NSString * const kMixpanelTimingPropertyKey = @"$duration";
 #ifdef AR_MIXPANEL_EXISTS
 
     NSAssert([Mixpanel class], @"Mixpanel is not included");
-    [Mixpanel sharedInstanceWithToken:identifier];
+    _mixpanel = [[Mixpanel alloc] initWithToken:identifier launchOptions:nil andFlushInterval:60];
 
     if (host) {
-        [[Mixpanel sharedInstance] setServerURL:host];
+        _mixpanel.serverURL = host;
     }
 #endif
     return [super init];
@@ -26,24 +30,24 @@ static NSString * const kMixpanelTimingPropertyKey = @"$duration";
 #ifdef AR_MIXPANEL_EXISTS
 - (void)identifyUserWithID:(NSString *)userID andEmailAddress:(NSString *)email {
     if (userID) {
-        [[Mixpanel sharedInstance] identify:userID];
+        [self.mixpanel identify:userID];
     }
 
     if (email) {
-        [[[Mixpanel sharedInstance] people] set:@"$email" to:email];
+        [[self.mixpanel people] set:@"$email" to:email];
     }
 }
 
 - (void)setUserProperty:(NSString *)property toValue:(NSString *)value {
-    [[[Mixpanel sharedInstance] people] set:property to:value];
+    [[self.mixpanel people] set:property to:value];
 }
 
 - (void)incrementUserProperty:(NSString *)counterName byInt:(NSNumber *)amount {
-    [[[Mixpanel sharedInstance] people] increment:counterName by:amount];
+    [[self.mixpanel people] increment:counterName by:amount];
 }
 
 - (void)event:(NSString *)event withProperties:(NSDictionary *)properties {
-    [[Mixpanel sharedInstance] track:event properties:properties];
+    [self.mixpanel track:event properties:properties];
 }
 
 - (void)logTimingEvent:(NSString *)event withInterval:(NSNumber *)interval properties:(NSDictionary *)properties {
@@ -60,6 +64,12 @@ static NSString * const kMixpanelTimingPropertyKey = @"$duration";
     }
     
     [self event:event withProperties:mutableProperties];
+}
+
+- (void)createAlias:(NSString *)alias
+{
+    [self.mixpanel createAlias:alias forDistinctID:self.mixpanel.distinctId];
+    [self identifyUserWithID:alias andEmailAddress:nil];
 }
 
 #endif

--- a/Providers/MixpanelProvider.m
+++ b/Providers/MixpanelProvider.m
@@ -18,7 +18,15 @@ static NSString * const kMixpanelTimingPropertyKey = @"$duration";
 #ifdef AR_MIXPANEL_EXISTS
 
     NSAssert([Mixpanel class], @"Mixpanel is not included");
-    _mixpanel = [[Mixpanel alloc] initWithToken:identifier launchOptions:nil andFlushInterval:60];
+
+    static dispatch_once_t onceToken;
+    dispatch_once(&onceToken, ^{
+        _mixpanel = [Mixpanel sharedInstanceWithToken:identifier];
+    });
+
+    if(! _mixpanel) {
+        _mixpanel = [[Mixpanel alloc] initWithToken:identifier launchOptions:nil andFlushInterval:60];
+    }
 
     if (host) {
         _mixpanel.serverURL = host;


### PR DESCRIPTION
This avoids using the singleton-style Mixpanel API.  I'm working on a project where we need more than one Mixpanel tracker available during the execution of our app.  Also this PR adds a new method to create an alias for a distinct id.