### PR TITLE
Removed non-existent kitForClass call for Fabric 1.4

### DIFF
--- a/Providers/FabricProvider.h
+++ b/Providers/FabricProvider.h
@@ -8,7 +8,6 @@
 @interface Fabric : NSObject
 + (instancetype)with:(NSArray *)kits;
 + (instancetype)sharedSDK;
-- (id)kitForClass:(Class)klass;
 @end
 
 OBJC_EXTERN void CLSLog(NSString *format, ...) NS_FORMAT_FUNCTION(1,2);

--- a/Providers/FabricProvider.m
+++ b/Providers/FabricProvider.m
@@ -20,7 +20,7 @@
     
     [Fabric with:kits];
     
-    if (![[Fabric sharedSDK] kitForClass:[Crashlytics class]]){
+    if (![kits containsObject:[Crashlytics class]]){
         return nil;// we don't need provider in case if we are not interested in Crashlytics but want to initialize Fabric
     }
 


### PR DESCRIPTION
There was a leftover from previous Fabric versions. The code crashed upon launch with 'unrecognized selector sent to instance'.