### PR TITLE
Updated Flurry dependency

### DIFF
--- a/ARAnalytics.podspec
+++ b/ARAnalytics.podspec
@@ -14,7 +14,7 @@ Pod::Spec.new do |s|
 
   mixpanel       = { :spec_name => "Mixpanel",            :dependency => "Mixpanel" }
   localytics     = { :spec_name => "Localytics",          :dependency => "Localytics" }
-  flurry         = { :spec_name => "Flurry",              :dependency => "FlurrySDK" }
+  flurry         = { :spec_name => "Flurry",              :dependency => "Flurry-iOS-SDK" }
   google         = { :spec_name => "GoogleAnalytics",     :dependency => "Google/Analytics", :has_extension => true }
   kissmetrics    = { :spec_name => "KISSmetrics",         :dependency => "KISSmetrics" }
   crittercism    = { :spec_name => "Crittercism",         :dependency => "CrittercismSDK" }


### PR DESCRIPTION
"FlurrySDK has been deprecated in favor of Flurry-iOS-SDK"