### PR TITLE
Completely untested. Fix Localytics screen tracking using events. Should use dedicated screen tracking method instead.

### DIFF
--- a/Providers/LocalyticsProvider.m
+++ b/Providers/LocalyticsProvider.m
@@ -61,7 +61,7 @@
     [Localytics tagEvent:event attributes:properties];
 }
 
-- (void)didShowNewPageView:(NSString *)pageTitle {
+- (void)didShowNewPageView:(NSString *)pageTitle withProperties:(NSDictionary *)properties {
     [Localytics tagScreen:pageTitle];
 }
 


### PR DESCRIPTION
didShowNewPageView is not actually ever called. didShowNewPageView:withProperties: is called, but LocalyticsProvider does not implement it, so a normal event is triggered in ARAnalyticalProvider instead.

Completely untested.
