### PR TITLE
Mixpanel provider improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # ARAnalytics
 
+## Version 3.8.2
+
+* Updated Mixpanel provider with methods to set super properties and to clean stored properties/distinct IDs. (@rais38)
+
 ## Version 3.8.1
 
 * Adds AppSee support (@sgtsquiggs)

--- a/Providers/MixpanelProvider.h
+++ b/Providers/MixpanelProvider.h
@@ -5,4 +5,5 @@
 - (void)createAlias:(NSString *)alias;
 - (void)registerSuperProperties:(NSDictionary *)properties;
 - (NSDictionary *)currentSuperProperties;
+- (void)reset;
 @end

--- a/Providers/MixpanelProvider.h
+++ b/Providers/MixpanelProvider.h
@@ -3,4 +3,6 @@
 @interface MixpanelProvider : ARAnalyticalProvider
 - (id)initWithIdentifier:(NSString *)identifier andHost:(NSString *)host;
 - (void)createAlias:(NSString *)alias;
+- (void)registerSuperProperties:(NSDictionary *)properties;
+- (NSDictionary *)currentSuperProperties;
 @end

--- a/Providers/MixpanelProvider.m
+++ b/Providers/MixpanelProvider.m
@@ -80,5 +80,15 @@ static NSString * const kMixpanelTimingPropertyKey = @"$duration";
     [self identifyUserWithID:alias andEmailAddress:nil];
 }
 
+- (void)registerSuperProperties:(NSDictionary *)properties
+{
+    [self.mixpanel registerSuperProperties:properties];
+}
+
+- (NSDictionary *)currentSuperProperties
+{
+    return [self.mixpanel currentSuperProperties];
+}
+
 #endif
 @end

--- a/Providers/MixpanelProvider.m
+++ b/Providers/MixpanelProvider.m
@@ -90,5 +90,10 @@ static NSString * const kMixpanelTimingPropertyKey = @"$duration";
     return [self.mixpanel currentSuperProperties];
 }
 
+- (void)reset
+{
+    [self.mixpanel reset];
+}
+
 #endif
 @end


### PR DESCRIPTION
Update `MixpanelProvider` with useful methods:

- Register and acces to super properties.
- Clears all stored properties and distinct IDs (user logs out).