### PR TITLE
Adding MobileAppTracker aka Tune library to the providers.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,9 @@
-language: objective-c
+brew updatelanguage: objective-c
 before_script:
   - echo -e "Host *\n\tStrictHostKeyChecking no\n" >> ~/.ssh/config
   - export LANG=en_US.UTF-8
-  - gem i cocoapods --no-ri --no-rdoc
-  - brew update
-  - brew uninstall xctool
-  - brew install xctool
   - cd Example; pod update ; cd ..
 xcode_workspace: Example/ARAnalyticsTests.xcworkspace
 xcode_scheme: ARAnalyticsBootstrapiOS
 xcode_sdk: iphonesimulator
+osx_image: xcode7.1

--- a/ARAnalytics.h
+++ b/ARAnalytics.h
@@ -212,3 +212,6 @@ extern NSString * const ARKeenReadKey;
 extern NSString * const ARAdobeData;
 extern NSString * const ARInstallTrackerApplicationID;
 extern NSString * const ARAppseeAPIKey;
+extern NSString * const ARMobileAppTrackerAdvertiserID;
+extern NSString * const ARMobileAppTrackerConversionKey;
+extern NSString * const ARMobileAppTrackerAllowedEvents;

--- a/ARAnalytics.m
+++ b/ARAnalytics.m
@@ -171,6 +171,15 @@ static BOOL _ARLogShouldPrintStdout = YES;
 	if (analyticsDictionary[ARAppseeAPIKey]) {
 		[self setupAppseeWithAPIKey:analyticsDictionary[ARAppseeAPIKey]];
 	}
+    
+    if (analyticsDictionary[ARMobileAppTrackerAdvertiserID] &&
+        analyticsDictionary[ARMobileAppTrackerConversionKey] &&
+        analyticsDictionary[ARMobileAppTrackerAllowedEvents]) {
+        
+        [self setupMobileAppTrackerWithAdvertiserID:analyticsDictionary[ARMobileAppTrackerAdvertiserID]
+                                      conversionKey:analyticsDictionary[ARMobileAppTrackerConversionKey]
+                                      allowedEvents:analyticsDictionary[ARMobileAppTrackerAllowedEvents]];
+    }
 
     // Add future integrations here:
 
@@ -521,6 +530,15 @@ static BOOL _ARLogShouldPrintStdout = YES;
 #endif
 }
 
++ (void)setupMobileAppTrackerWithAdvertiserID:(NSString *)advertiserID conversionKey:(NSString *)conversionKey allowedEvents:(NSArray *)allowedEvents {
+#ifdef AR_MOBILEAPPTRACKER_EXISTS
+    MobileAppTrackerProvider *provider = [[MobileAppTrackerProvider alloc] initWithAdvertiserId:advertiserID
+                                                                                  conversionKey:conversionKey
+                                                                                  allowedEvents:allowedEvents];
+    [self setupProvider:provider];
+#endif
+}
+
 #pragma mark -
 #pragma mark User Setup
 
@@ -789,3 +807,6 @@ NSString * const ARKeenReadKey = @"ARKeenReadKey";
 NSString * const ARAdobeData = @"ARAdobeData";
 NSString * const ARInstallTrackerApplicationID = @"ARInstallTrackerApplicationID";
 NSString * const ARAppseeAPIKey = @"ARAppseeAPIKey";
+NSString * const ARMobileAppTrackerAdvertiserID = @"ARMobileAppTrackerAdvertiserID";
+NSString * const ARMobileAppTrackerConversionKey = @"ARMobileAppTrackerConversionKey";
+NSString * const ARMobileAppTrackerAllowedEvents = @"ARMobileAppTrackerAllowedEvents";

--- a/ARAnalytics.podspec
+++ b/ARAnalytics.podspec
@@ -12,40 +12,41 @@ Pod::Spec.new do |s|
   s.summary      =  'Using subspecs you can define your analytics provider with the same API on iOS and OS X.'
   # s.description is at the bottom as it is partially generated.
 
-  mixpanel       = { :spec_name => "Mixpanel",            :dependency => "Mixpanel" }
-  localytics     = { :spec_name => "Localytics",          :dependency => "Localytics" }
-  flurry         = { :spec_name => "Flurry",              :dependency => "Flurry-iOS-SDK" }
-  google         = { :spec_name => "GoogleAnalytics",     :dependency => "Google/Analytics", :has_extension => true }
-  kissmetrics    = { :spec_name => "KISSmetrics",         :dependency => "KISSmetrics" }
-  crittercism    = { :spec_name => "Crittercism",         :dependency => "CrittercismSDK" }
-  countly        = { :spec_name => "Countly",             :dependency => "Countly" }
-  bugsnag        = { :spec_name => "Bugsnag",             :dependency => "Bugsnag" }
-  helpshift      = { :spec_name => "Helpshift",           :dependency => "Helpshift" }
-  tapstream      = { :spec_name => "Tapstream",           :dependency => "Tapstream" }
-  newRelic       = { :spec_name => "NewRelic",            :dependency => "NewRelicAgent" }
-  amplitude      = { :spec_name => "Amplitude",           :dependency => "Amplitude-iOS" }
-  hockeyApp      = { :spec_name => "HockeyApp",           :dependency => "HockeySDK-Source" }
-  hockeyAppLib   = { :spec_name => "HockeyAppLib",        :dependency => "HockeySDK" }
-  parseAnalytics = { :spec_name => "ParseAnalytics",      :dependency => "Parse", :has_extension => true }
-  heap           = { :spec_name => "HeapAnalytics",       :dependency => "Heap" }
-  chartbeat      = { :spec_name => "Chartbeat",           :dependency => "Chartbeat", :has_extension => true }
-  umeng          = { :spec_name => "UMengAnalytics",      :dependency => "UMengAnalytics" }
-  segmentio      = { :spec_name => "Segmentio",           :dependency => "Analytics/Segmentio" , :tvos => true}
-  swrve          = { :spec_name => "Swrve",               :dependency => "SwrveSDK" }
-  yandex         = { :spec_name => "YandexMobileMetrica", :dependency => "YandexMobileMetrica" }
-  adjust         = { :spec_name => "Adjust",              :dependency => "Adjust" }
-  intercom       = { :spec_name => "Intercom",            :dependency => "Intercom" }
-  librato        = { :spec_name => "Librato" }
-  crashlytics    = { :spec_name => "Crashlytics",         :dependency => "Crashlytics" }
-  fabric         = { :spec_name => "Fabric",              :dependency => ["Fabric", "Crashlytics"] }
-  appsflyer      = { :spec_name => "AppsFlyer",           :dependency => "AppsFlyer-SDK" }
-  branch         = { :spec_name => "Branch",              :dependency => "Branch" }
-  snowplow       = { :spec_name => "Snowplow",            :dependency => "SnowplowTracker" }
-  sentry         = { :spec_name => "Sentry",              :dependency => "Raven" }
-  keen           = { :spec_name => "Keen",                :dependency => "KeenClient" }
-  adobe          = { :spec_name => "Adobe",               :dependency => "AdobeMobileSDK" }
-  installtracker = { :spec_name => "InstallTracker",      :dependency => "InstallTracker"}
-  appsee         = { :spec_name => "Appsee",              :dependency => "Appsee" }
+  mixpanel         = { :spec_name => "Mixpanel",            :dependency => "Mixpanel" }
+  localytics       = { :spec_name => "Localytics",          :dependency => "Localytics" }
+  flurry           = { :spec_name => "Flurry",              :dependency => "Flurry-iOS-SDK" }
+  google           = { :spec_name => "GoogleAnalytics",     :dependency => "Google/Analytics", :has_extension => true }
+  kissmetrics      = { :spec_name => "KISSmetrics",         :dependency => "KISSmetrics" }
+  crittercism      = { :spec_name => "Crittercism",         :dependency => "CrittercismSDK" }
+  countly          = { :spec_name => "Countly",             :dependency => "Countly" }
+  bugsnag          = { :spec_name => "Bugsnag",             :dependency => "Bugsnag" }
+  helpshift        = { :spec_name => "Helpshift",           :dependency => "Helpshift" }
+  tapstream        = { :spec_name => "Tapstream",           :dependency => "Tapstream" }
+  newRelic         = { :spec_name => "NewRelic",            :dependency => "NewRelicAgent" }
+  amplitude        = { :spec_name => "Amplitude",           :dependency => "Amplitude-iOS" }
+  hockeyApp        = { :spec_name => "HockeyApp",           :dependency => "HockeySDK-Source" }
+  hockeyAppLib     = { :spec_name => "HockeyAppLib",        :dependency => "HockeySDK" }
+  parseAnalytics   = { :spec_name => "ParseAnalytics",      :dependency => "Parse", :has_extension => true }
+  heap             = { :spec_name => "HeapAnalytics",       :dependency => "Heap" }
+  chartbeat        = { :spec_name => "Chartbeat",           :dependency => "Chartbeat", :has_extension => true }
+  umeng            = { :spec_name => "UMengAnalytics",      :dependency => "UMengAnalytics" }
+  segmentio        = { :spec_name => "Segmentio",           :dependency => "Analytics/Segmentio" , :tvos => true}
+  swrve            = { :spec_name => "Swrve",               :dependency => "SwrveSDK" }
+  yandex           = { :spec_name => "YandexMobileMetrica", :dependency => "YandexMobileMetrica" }
+  adjust           = { :spec_name => "Adjust",              :dependency => "Adjust" }
+  intercom         = { :spec_name => "Intercom",            :dependency => "Intercom" }
+  librato          = { :spec_name => "Librato" }
+  crashlytics      = { :spec_name => "Crashlytics",         :dependency => "Crashlytics" }
+  fabric           = { :spec_name => "Fabric",              :dependency => ["Fabric", "Crashlytics"] }
+  appsflyer        = { :spec_name => "AppsFlyer",           :dependency => "AppsFlyer-SDK" }
+  branch           = { :spec_name => "Branch",              :dependency => "Branch" }
+  snowplow         = { :spec_name => "Snowplow",            :dependency => "SnowplowTracker" }
+  sentry           = { :spec_name => "Sentry",              :dependency => "Raven" }
+  keen             = { :spec_name => "Keen",                :dependency => "KeenClient" }
+  adobe            = { :spec_name => "Adobe",               :dependency => "AdobeMobileSDK" }
+  installtracker   = { :spec_name => "InstallTracker",      :dependency => "InstallTracker"}
+  appsee           = { :spec_name => "Appsee",              :dependency => "Appsee" }
+  mobileapptracker = { :spec_name => "MobileAppTracker",    :dependency => "MobileAppTracker"}
 
   kissmetrics_mac = { :spec_name => "KISSmetricsOSX",  :dependency => "KISSmetrics",            :osx => true,  :provider => "KISSmetrics" }
 # countly_mac     = { :spec_name => "CountlyOSX",      :dependency => "Countly",                :osx => true,  :provider => "Countly" }
@@ -54,7 +55,7 @@ Pod::Spec.new do |s|
   parseAnalytics_mac = { :spec_name => "ParseAnalyticsOSX", :dependency => "Parse",             :osx => true,  :provider => "ParseAnalytics", :has_extension => true }
 
 
-  all_analytics = [mixpanel, localytics, flurry, google, kissmetrics, crittercism, crashlytics, fabric, bugsnag, countly, helpshift, kissmetrics_mac, mixpanel_mac, tapstream, newRelic, amplitude, hockeyApp, hockeyAppLib, hockeyApp_mac, parseAnalytics, parseAnalytics_mac, heap, chartbeat, umeng, librato, segmentio, swrve, yandex, adjust, appsflyer, branch, snowplow, sentry, intercom, keen, adobe, installtracker, appsee]
+  all_analytics = [mixpanel, localytics, flurry, google, kissmetrics, crittercism, crashlytics, fabric, bugsnag, countly, helpshift, kissmetrics_mac, mixpanel_mac, tapstream, newRelic, amplitude, hockeyApp, hockeyAppLib, hockeyApp_mac, parseAnalytics, parseAnalytics_mac, heap, chartbeat, umeng, librato, segmentio, swrve, yandex, adjust, appsflyer, branch, snowplow, sentry, intercom, keen, adobe, installtracker, appsee, mobileapptracker]
 
   # To make the pod spec API cleaner, subspecs are "iOS/KISSmetrics"
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # ARAnalytics
 
+## Version 3.8.2
+
+* Adds MobileAppTracker/Tune support (@fabiojgrocha)
+
 ## Version 3.8.1
 
 * Adds AppSee support (@sgtsquiggs)

--- a/Example/Podfile.lock
+++ b/Example/Podfile.lock
@@ -31,7 +31,7 @@ EXTERNAL SOURCES:
     :path: ../
 
 SPEC CHECKSUMS:
-  ARAnalytics: 1cc9dfe60262e5952aa959a87f5f34d6c931f562
+  ARAnalytics: 3f46c97db3259614a2c1fb840039cf4bf59356ce
   Expecta: 78b4e8b0c8291fa4524d7f74016b6065c2e391ec
   Intercom: 49dfec2dadadba595705e43b30f1148ed799fbc3
   OCMock: a6a7dc0e3997fb9f35d99f72528698ebf60d64f2

--- a/Providers/ARAnalyticsProviders.h
+++ b/Providers/ARAnalyticsProviders.h
@@ -138,3 +138,7 @@
 #ifdef AR_APPSEE_EXISTS
 #import "AppseeProvider.h"
 #endif
+
+#ifdef AR_MOBILEAPPTRACKER_EXISTS
+#import "MobileAppTrackerProvider.h"
+#endif

--- a/Providers/MobileAppTrackerProvider.h
+++ b/Providers/MobileAppTrackerProvider.h
@@ -1,0 +1,14 @@
+#import "ARAnalyticalProvider.h"
+
+@interface MobileAppTrackerProvider : ARAnalyticalProvider
+
+/** Each event has associated billing charges, so we don't necessarely want every event to be sent.
+ *  @link http://help.tune.com/marketing-console/in-app-events-which-ones-you-should-be-measuring-and-why/
+ */
+@property (nonatomic, strong) NSArray *allowedEvents;
+
+- (instancetype)initWithAdvertiserId:(NSString *)advertiserId
+                       conversionKey:(NSString *)conversionKey
+                       allowedEvents:(NSArray *)allowedEvents;
+
+@end

--- a/Providers/MobileAppTrackerProvider.m
+++ b/Providers/MobileAppTrackerProvider.m
@@ -1,0 +1,69 @@
+#import <MobileAppTracker/Tune.h>
+#import <MobileAppTracker/TuneEvent.h>
+#import "ARAnalyticsProviders.h"
+
+@import AdSupport.ASIdentifierManager;
+
+@implementation MobileAppTrackerProvider
+#ifdef AR_MOBILEAPPTRACKER_EXISTS
+
+#pragma mark - Lifecyle
+
+- (instancetype)initWithAdvertiserId:(NSString *)advertiserId
+                       conversionKey:(NSString *)conversionKey
+                       allowedEvents:(NSArray *)allowedEvents {
+    
+    NSAssert([Tune class], @"MobileAppTracker/Tune is not included");
+    
+    self = [super init];
+    
+    if (self) {
+    
+        [Tune initializeWithTuneAdvertiserId:advertiserId tuneConversionKey:conversionKey];
+        [Tune setAppleAdvertisingIdentifier:[[ASIdentifierManager sharedManager] advertisingIdentifier]
+                 advertisingTrackingEnabled:[[ASIdentifierManager sharedManager] isAdvertisingTrackingEnabled]];
+        
+        self.allowedEvents = allowedEvents;
+        [self registerNotifications];
+    }
+    
+    return self;
+}
+
+- (void)dealloc {
+
+    [self unregisterNotifications];
+}
+
+#pragma mark - Overwrites
+
+- (void)event:(NSString *)event withProperties:(NSDictionary *)properties {
+    
+    if ([self.allowedEvents containsObject:event]) {
+    
+        TuneEvent *tuneEvent = [TuneEvent eventWithName:event];
+        [Tune measureEvent:tuneEvent];
+    }
+}
+
+#pragma mark - Notifications
+
+- (void)registerNotifications {
+
+    [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(applicationDidBecomeActive:)
+                                                 name:UIApplicationDidBecomeActiveNotification
+                                               object:nil];
+}
+
+- (void)unregisterNotifications {
+
+    [[NSNotificationCenter defaultCenter] removeObserver:self];
+}
+
+- (void)applicationDidBecomeActive:(NSNotification *)notification {
+
+    [Tune measureSession];
+}
+
+#endif
+@end

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ ARAnalytics v3.X.Y [![Build Status](https://travis-ci.org/orta/ARAnalytics.svg?b
 
 ARAnalytics is to iOS what [Analytical](https://github.com/jkrall/analytical) is to ruby, or [Analytics.js](http://segmentio.github.com/analytics.js/) is to javascript.
 
-ARAnalytics is an analytics abstraction library offering a sane API for tracking events and user data. It currently supports on iOS: Mixpanel, Localytics, Flurry, GoogleAnalytics, KISSmetrics, Crittercism, Crashlytics, Fabric, Bugsnag, Countly, Helpshift, Tapstream, NewRelic, Amplitude, HockeyApp, HockeyAppLib, ParseAnalytics, HeapAnalytics, Chartbeat, UMengAnalytics, Librato, Segmentio, Swrve, YandexMobileMetrica, Adjust, AppsFlyer, Branch, Snowplow, Sentry, Intercom, Keen and Adobe. And for OS X: KISSmetrics, Mixpanel and HockeyApp. 
+ARAnalytics is an analytics abstraction library offering a sane API for tracking events and user data. It currently supports on iOS: Mixpanel, Localytics, Flurry, GoogleAnalytics, KISSmetrics, Crittercism, Crashlytics, Fabric, Bugsnag, Countly, Helpshift, Tapstream, NewRelic, Amplitude, HockeyApp, HockeyAppLib, ParseAnalytics, HeapAnalytics, Chartbeat, UMengAnalytics, Librato, Segmentio, Swrve, YandexMobileMetrica, Adjust, AppsFlyer, Branch, Snowplow, Sentry, Intercom, Keen, Adobe and MobileAppTracker/Tune. And for OS X: KISSmetrics, Mixpanel and HockeyApp. 
 
 It does this by using CocoaPods subspecs to let you decide which libraries you'd like to use. You are free to also use the official API for any provider too. Also, it comes with an amazing [DSL](#aspect-oriented-dsl) to clear up your methods.
 
@@ -152,7 +152,7 @@ Note, however, that on iOS `syslogd` will not keep logs around for a long time, 
 Full list of subspecs
 ----
 
-iOS: `Mixpanel`, `Localytics`, `Flurry`, `GoogleAnalytics`, `KISSmetrics`, `Crittercism`, `Countly`, `Bugsnag`, `Helpshift`, `Tapstream`, `NewRelic`, `Amplitude`, `HockeyApp`, `HockeyAppLib`, `ParseAnalytics`, `HeapAnalytics`, `Chartbeat`, `UMengAnalytics`, `Segmentio`, `Swrve`, `YandexMobileMetrica`, `Adjust`, `Intercom`, `Librato`, `Crashlytics`, `Fabric`, `AppsFlyer`, `Branch`, `Snowplow`, `Sentry`, `Keen` & `Adobe`.
+iOS: `Mixpanel`, `Localytics`, `Flurry`, `GoogleAnalytics`, `KISSmetrics`, `Crittercism`, `Countly`, `Bugsnag`, `Helpshift`, `Tapstream`, `NewRelic`, `Amplitude`, `HockeyApp`, `HockeyAppLib`, `ParseAnalytics`, `HeapAnalytics`, `Chartbeat`, `UMengAnalytics`, `Segmentio`, `Swrve`, `YandexMobileMetrica`, `Adjust`, `Intercom`, `Librato`, `Crashlytics`, `Fabric`, `AppsFlyer`, `Branch`, `Snowplow`, `Sentry`, `Keen`, `Adobe` & `MobileAppTracker`.
 
 OSX: `KISSmetricsOSX`, `HockeyAppOSX`, `MixpanelOSX` & `ParseAnalyticsOSX`.
 


### PR DESCRIPTION
Added MobileAppTracker/Tune to the providers.
This implementation is not 100% complete as MobileAppTracker can receive more details, but it is enough to initialise and track events.
Also this lib has a small diference from the others, each new event is paid, that's why I've created a whitelist called "allowedEvents", so the events accepted events have to be specified while initializing the lib.