### PR TITLE
Allow custom properties for screen tracking events (Mixpanel)

### DIFF
--- a/Providers/MixpanelProvider.h
+++ b/Providers/MixpanelProvider.h
@@ -1,5 +1,7 @@
 #import "ARAnalyticalProvider.h"
 
+extern NSString *const ARMixpanelTrackedScreenEventName;
+
 @interface MixpanelProvider : ARAnalyticalProvider
 - (id)initWithIdentifier:(NSString *)identifier andHost:(NSString *)host;
 - (void)createAlias:(NSString *)alias;


### PR DESCRIPTION
With current implementation, in screen tracking events at Mixpanel, our events are called "Screen view" always and there is not possibility to set from the DSL.

For this reason, I added `ARMixpanelTrackedScreenEventName` property in `MixpanelProvider`:

```
[ARAnalytics setupWithAnalytics: @{ /* keys */ } configuration: @{
   ARAnalyticsTrackedScreens: @[ @{
      ARAnalyticsClass: UIViewController.class,
      ARAnalyticsDetails: @[ @{
          ARAnalyticsPageNameKeyPath: @"title",
          ARAnalyticsProperties: ^NSDictionary*(UIViewController *controller, NSArray *parameters) {
                                                 return @{
                                                          ARMixpanelTrackedScreenEventName: @"custom_name"
                                                          };
                                             }
      }]
  }],
...
```