### PR TITLE
Add support for optional anonymous ID

### DIFF
--- a/ARAnalyticalProvider.h
+++ b/ARAnalyticalProvider.h
@@ -9,8 +9,14 @@ extern NSString *const ARAnalyticalProviderNewPageViewEventScreenPropertyKey;
 - (id)initWithIdentifier:(NSString *)identifier;
 
 /// Set a per user property
-- (void)identifyUserWithID:(NSString *)userID andEmailAddress:(NSString *)email;
 - (void)setUserProperty:(NSString *)property toValue:(NSString *)value;
+- (void)identifyUserWithID:(NSString *)userID andEmailAddress:(NSString *)email;
+
+/// For backwards compatibility, this method by default invokes `-identifyUserWithID:andEmailAddress:` and assigns the
+/// `anonymousID` as a user property, if given, with the key `anonymous_id`.
+///
+/// @note If you override this method, be sure to also override that method and have it invoke this one instead.
+- (void)identifyUserWithID:(NSString *)userID anonymousID:(NSString *)anonymousID andEmailAddress:(NSString *)email;
 
 /// Submit user events
 - (void)event:(NSString *)event withProperties:(NSDictionary *)properties;

--- a/ARAnalyticalProvider.m
+++ b/ARAnalyticalProvider.m
@@ -22,6 +22,12 @@ NSString *const ARAnalyticalProviderNewPageViewEventScreenPropertyKey = @"screen
     return [super init];
 }
 
+- (void)identifyUserWithID:(NSString *)userID anonymousID:(NSString *)anonymousID andEmailAddress:(NSString *)email {
+    [self identifyUserWithID:userID andEmailAddress:email];
+    if (anonymousID) {
+        [self setUserProperty:@"anonymous_id" toValue:anonymousID];
+    }
+}
 - (void)identifyUserWithID:(NSString *)userID andEmailAddress:(NSString *)email {}
 - (void)setUserProperty:(NSString *)property toValue:(NSString *)value {}
 

--- a/ARAnalytics.h
+++ b/ARAnalytics.h
@@ -103,6 +103,12 @@
 /// Register a user and an associated email address, it is fine to send nils for either.
 + (void)identifyUserWithID:(NSString *)userID andEmailAddress:(NSString *)email;
 
+/// Register a user and an associated email address, in addition allows you to pass in an ID that you previously used
+/// to track events when the user did not authenticate yet. E.g. `-[UIDevice identifierForVendor]`.
+///
+/// Currently only the Segment provider makes use of this and only when using version TODO or up of their SDK.
++ (void)identifyUserWithID:(NSString *)userID anonymousID:(NSString *)anonymousID andEmailAddress:(NSString *)email;
+
 /// Set a per user property
 + (void)setUserProperty:(NSString *)property toValue:(NSString *)value;
 

--- a/ARAnalytics.m
+++ b/ARAnalytics.m
@@ -168,9 +168,9 @@ static BOOL _ARLogShouldPrintStdout = YES;
         [self setupInstallTrackerWithApplicationID:analyticsDictionary[ARInstallTrackerApplicationID]];
     }
 
-	if (analyticsDictionary[ARAppseeAPIKey]) {
-		[self setupAppseeWithAPIKey:analyticsDictionary[ARAppseeAPIKey]];
-	}
+    if (analyticsDictionary[ARAppseeAPIKey]) {
+        [self setupAppseeWithAPIKey:analyticsDictionary[ARAppseeAPIKey]];
+    }
     
     if (analyticsDictionary[ARMobileAppTrackerAdvertiserID] &&
         analyticsDictionary[ARMobileAppTrackerConversionKey] &&
@@ -544,8 +544,13 @@ static BOOL _ARLogShouldPrintStdout = YES;
 
 + (void)identifyUserWithID:(NSString *)userID andEmailAddress:(NSString *)email
 {
+    [self identifyUserWithID:userID anonymousID:nil andEmailAddress:email];
+}
+
++ (void)identifyUserWithID:(NSString *)userID anonymousID:(NSString *)anonymousID andEmailAddress:(NSString *)email;
+{
     [_sharedAnalytics iterateThroughProviders:^(ARAnalyticalProvider *provider) {
-        [provider identifyUserWithID:userID andEmailAddress:email];
+        [provider identifyUserWithID:userID anonymousID:anonymousID andEmailAddress:email];
     }];
 }
 

--- a/ARAnalytics.podspec
+++ b/ARAnalytics.podspec
@@ -29,7 +29,7 @@ Pod::Spec.new do |s|
   heap             = { :spec_name => "HeapAnalytics",       :dependency => "Heap" }
   chartbeat        = { :spec_name => "Chartbeat",           :dependency => "Chartbeat", :has_extension => true }
   umeng            = { :spec_name => "UMengAnalytics",      :dependency => "UMengAnalytics" }
-  segmentio        = { :spec_name => "Segmentio",           :dependency => "Analytics/Segmentio" , :tvos => true}
+  segmentio        = { :spec_name => "Segmentio",           :dependency => [["Analytics", ">= 3"]], :tvos => true}
   swrve            = { :spec_name => "Swrve",               :dependency => "SwrveSDK" }
   yandex           = { :spec_name => "YandexMobileMetrica", :dependency => "YandexMobileMetrica" }
   adjust           = { :spec_name => "Adjust",              :dependency => "Adjust" }
@@ -116,7 +116,7 @@ Pod::Spec.new do |s|
 
       # If there's a podspec dependency include it
       Array(analytics_spec[:dependency]).each do |dep|
-          ss.dependency dep
+          ss.dependency *dep
       end
 
     end

--- a/ARAnalytics.podspec
+++ b/ARAnalytics.podspec
@@ -106,10 +106,11 @@ Pod::Spec.new do |s|
       else
         ss.ios.source_files = sources
         ss.dependency 'ARAnalytics/CoreIOS'
-        ss.platform = :ios
         if analytics_spec[:tvos]
           ss.tvos.source_files = sources
-          ss.platform = :tvos
+          ss.platforms = [:ios, :tvos]
+        else
+          ss.platform = :ios
         end
         all_ios_names << providername
       end

--- a/Example/ARAnalyticsiOSTests/ARAnalyticsiOSTests.m
+++ b/Example/ARAnalyticsiOSTests/ARAnalyticsiOSTests.m
@@ -65,6 +65,7 @@ describe(@"ARAnalytics API", ^{
     
     afterEach(^{
         [ARAnalytics removeProvider:provider];
+        [ARAnalytics removeEventSuperProperty:@"paint"];
     });
     
     describe(@"User Properties", ^{

--- a/Example/ARAnalyticsiOSTests/ARAnalyticsiOSTests.m
+++ b/Example/ARAnalyticsiOSTests/ARAnalyticsiOSTests.m
@@ -59,12 +59,13 @@ describe(@"ARAnalytics API", ^{
     __block ORStubbedProvider *provider = nil;
     
     beforeEach(^{
-        if(provider) [ARAnalytics removeProvider:provider];
-        
         provider = [[ORStubbedProvider alloc] init];
         [ARAnalytics setupProvider:provider];
     });
     
+    afterEach(^{
+        [ARAnalytics removeProvider:provider];
+    });
     
     describe(@"User Properties", ^{
         it(@"provider reacts to identifyUserWithID:andEmailAddress:", ^{

--- a/Example/Podfile.lock
+++ b/Example/Podfile.lock
@@ -7,7 +7,7 @@ PODS:
     - ARAnalytics/CoreIOS
     - Intercom
   - Expecta (0.4.2)
-  - Intercom (2.3.15)
+  - Intercom (2.3.16)
   - OCMock (2.2.4)
   - ReactiveCocoa (2.5):
     - ReactiveCocoa/UI (= 2.5)
@@ -28,12 +28,12 @@ DEPENDENCIES:
 
 EXTERNAL SOURCES:
   ARAnalytics:
-    :path: "../"
+    :path: ../
 
 SPEC CHECKSUMS:
   ARAnalytics: 2d3ab0af06af77e85307236bb12bf83622c50a96
   Expecta: 78b4e8b0c8291fa4524d7f74016b6065c2e391ec
-  Intercom: 49dfec2dadadba595705e43b30f1148ed799fbc3
+  Intercom: 296dfb41c92ff90de23adb1d975d337aa9dd422f
   OCMock: a6a7dc0e3997fb9f35d99f72528698ebf60d64f2
   ReactiveCocoa: e2db045570aa97c695e7aa97c2bcab222ae51f4a
   RSSwizzle: d561958f595028bfcef98c7d55c318b3878a61c6

--- a/Providers/SegmentioProvider.m
+++ b/Providers/SegmentioProvider.m
@@ -51,7 +51,7 @@
     [self _setUserProperty:property toValue:value];
     if (self.hasIdentified) {
 #ifdef DEBUG
-#warning "Calling -[SegmentioProvider setUserProperty:toValue:] after identifying will perform an identity request for each call."
+        NSLog(@"Calling -[SegmentioProvider setUserProperty:toValue:] after identifying will perform an identity request for each call.");
 #endif
         [self identify];
     }

--- a/Providers/SegmentioProvider.m
+++ b/Providers/SegmentioProvider.m
@@ -6,21 +6,65 @@
 #import "ARAnalyticsProviders.h"
 #import "Analytics.h"
 
+#ifdef AR_SEGMENTIO_EXISTS
+@interface SegmentioProvider ()
+@property (assign) BOOL hasIdentified;
+@property (copy) NSString *userID;
+@property (copy) NSString *anonymousID;
+@property (copy) NSDictionary *traits;
+@end
+#endif
+
 @implementation SegmentioProvider
 
 #ifdef AR_SEGMENTIO_EXISTS
 - (id)initWithIdentifier:(NSString *)identifier {
-    [SEGAnalytics setupWithConfiguration:[SEGAnalyticsConfiguration configurationWithWriteKey:identifier]];
-    return [super init];
+    if ((self = [super initWithIdentifier:identifier])) {
+        [SEGAnalytics setupWithConfiguration:[SEGAnalyticsConfiguration configurationWithWriteKey:identifier]];
+        _traits = @{};
+    }
+    return self;
 }
 
 - (void)identifyUserWithID:(NSString *)userID andEmailAddress:(NSString *)email {
-    if (userID && email) {
-        [[SEGAnalytics sharedAnalytics] identify:userID traits:@{ @"email": email }];
+    [self identifyUserWithID:userID anonymousID:nil andEmailAddress:email];
+}
+
+- (void)identifyUserWithID:(NSString *)userID anonymousID:(NSString *)anonymousID andEmailAddress:(NSString *)email {
+    self.userID = userID;
+    self.anonymousID = anonymousID;
+    if (email) {
+        [self _setUserProperty:@"email" toValue:email];
     }
-    else if (userID) {
-        [[SEGAnalytics sharedAnalytics] identify:userID];
+    [self _identify];
+}
+
+- (void)_identify {
+    NSDictionary *options = self.anonymousID == nil ?: @{ @"anonymousId": self.anonymousID };
+    [[SEGAnalytics sharedAnalytics] identify:self.userID traits:self.traits options:options];
+    self.hasIdentified = YES;
+}
+
+// This will only call -identify if the user has identified before. This makes it possible to first set multiple
+// properties without making multiple identify requests.
+- (void)setUserProperty:(NSString *)property toValue:(NSString *)value {
+    [self _setUserProperty:property toValue:value];
+    if (self.hasIdentified) {
+#ifdef DEBUG
+#warning "Calling -[SegmentioProvider setUserProperty:toValue:] after identifying will perform an identity request for each call."
+#endif
+        [self identify];
     }
+}
+
+- (void)_setUserProperty:(NSString *)property toValue:(NSString *)value {
+    NSMutableDictionary *traits = [self.traits mutableCopy];
+    if (value) {
+        traits[property] = value;
+    } else {
+        [traits removeObjectForKey:property];
+    }
+    self.traits = traits;
 }
 
 - (void)event:(NSString *)event withProperties:(NSDictionary *)properties {


### PR DESCRIPTION
Adding an extra provider specific setup method for this just didn’t sit well with me.

- Segment: Uses new anonymous ID support https://github.com/segmentio/analytics-ios/pull/485
- Others: Assigns the anonymous ID as a user property with the key `anonymous_id`.

![](http://media4.giphy.com/media/i1zNFnz0skz4s/giphy.gif)