### PR TITLE
Adobe provider screen views with props

### DIFF
--- a/ARAnalytics.h
+++ b/ARAnalytics.h
@@ -81,7 +81,8 @@
 + (void)setupSentryWithID:(NSString *)identifier;
 + (void)setupIntercomWithAppID:(NSString *)identifier apiKey:(NSString *)apiKey;
 + (void)setupKeenWithProjectID:(NSString *)projectId andWriteKey:(NSString *)writeKey andReadKey:(NSString *)readKey;
-+ (void)setupAdobeWithData:(NSDictionary *)additionalData;
+
++ (void)setupAdobeWithData:(NSDictionary *)additionalData otherSettings:(NSDictionary *)settings;
 + (void)setupInstallTrackerWithApplicationID:(NSString *)applicationID;
 + (void)setupAppseeWithAPIKey:(NSString *)key;
 + (void)setupMobileAppTrackerWithAdvertiserID:(NSString *)advertiserID conversionKey:(NSString *)conversionKey allowedEvents:(NSArray *)allowedEvents;
@@ -219,6 +220,7 @@ extern NSString * const ARKeenProjectID;
 extern NSString * const ARKeenWriteKey;
 extern NSString * const ARKeenReadKey;
 extern NSString * const ARAdobeData;
+extern NSString * const ARAdobeSettings;
 extern NSString * const ARInstallTrackerApplicationID;
 extern NSString * const ARAppseeAPIKey;
 extern NSString * const ARMobileAppTrackerAdvertiserID;

--- a/ARAnalytics.m
+++ b/ARAnalytics.m
@@ -162,7 +162,7 @@ static BOOL _ARLogShouldPrintStdout = YES;
     }
 
     if (analyticsDictionary[ARAdobeData]) {
-        [self setupAdobeWithData:analyticsDictionary[ARAdobeData]];
+        [self setupAdobeWithData:analyticsDictionary[ARAdobeData] otherSettings:analyticsDictionary[ARAdobeSettings]];
     }
     
     if (analyticsDictionary[ARInstallTrackerApplicationID]) {
@@ -511,10 +511,9 @@ static BOOL _ARLogShouldPrintStdout = YES;
 #endif
 }
 
-+ (void)setupAdobeWithData:(NSDictionary *)additionalData
-{
++ (void)setupAdobeWithData:(NSDictionary *)additionalData otherSettings:(NSDictionary *)settings {
 #ifdef AR_ADOBE_EXISTS
-    AdobeProvider *provider = [[AdobeProvider alloc] initWithData:additionalData];
+    AdobeProvider *provider = [[AdobeProvider alloc] initWithData:additionalData settings:settings];
     [self setupProvider:provider];
 #endif
 }
@@ -824,6 +823,7 @@ NSString * const ARKeenProjectID = @"ARKeenProjectID";
 NSString * const ARKeenWriteKey = @"ARKeenWriteKey";
 NSString * const ARKeenReadKey = @"ARKeenReadKey";
 NSString * const ARAdobeData = @"ARAdobeData";
+NSString * const ARAdobeSettings = @"ARAdobeSettings";
 NSString * const ARInstallTrackerApplicationID = @"ARInstallTrackerApplicationID";
 NSString * const ARAppseeAPIKey = @"ARAppseeAPIKey";
 NSString * const ARMobileAppTrackerAdvertiserID = @"ARMobileAppTrackerAdvertiserID";

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Version 3.9.1
 * Add support for dynamic page names and event names in the DSL (@arifken)
+* Add configuration setting to the Adobe provider for -trackAction:data: vs. -trackState:data: for screen views. When enabled, allows page views with custom properties to be tracked with -trackState:data: (@arifken)
 
 ## Version 3.9.0
 

--- a/Example/ARAnalyticsiOSTests/ProviderTests/AdobeProviderTests.m
+++ b/Example/ARAnalyticsiOSTests/ProviderTests/AdobeProviderTests.m
@@ -1,0 +1,62 @@
+#import <ARAnalytics/ARAnalytics.h>
+#import <OCMock/OCMock.h>
+#import "AdobeProvider.h"
+#import "ADBMobile.h"
+
+SpecBegin(AdobeProviderTests)
+
+    describe(@"Adobe Providers", ^{
+
+        __block id adbMobileMock = nil;
+
+        beforeEach(^{
+            adbMobileMock = OCMClassMock([ADBMobile class]);
+            OCMStub([adbMobileMock collectLifecycleData]);
+            OCMStub([adbMobileMock collectLifecycleDataWithAdditionalData:[OCMArg any]]);
+        });
+
+        afterEach(^{
+            [adbMobileMock stopMocking];
+        });
+
+        it(@"Adds an Adobe provider with the default settings", ^{
+            AdobeProvider *provider = [[AdobeProvider alloc] initWithData:@{}];
+            [ARAnalytics setupProvider:provider];
+            expect([ARAnalytics currentProviders]).to.contain(provider);
+        });
+
+        it(@"Calls -trackState:data: for pageViews with no additional parameters", ^{
+            [[adbMobileMock reject] trackAction:[OCMArg any] data:[OCMArg any]];
+
+            AdobeProvider *provider = [[AdobeProvider alloc] initWithData:@{}];
+            [ARAnalytics setupProvider:provider];
+
+            [provider didShowNewPageView:@"page one"];
+            OCMVerify([adbMobileMock trackState:@"page one" data:[OCMArg isNil]]);
+        });
+
+        it(@"Calls -trackAction:data: for pageViews with additional parameters", ^{
+            [[adbMobileMock reject] trackState:[OCMArg any] data:[OCMArg any]];
+
+            AdobeProvider *provider = [[AdobeProvider alloc] initWithData:@{}];
+            [ARAnalytics setupProvider:provider];
+
+            [provider didShowNewPageView:@"page one" withProperties:@{@"color" : @"blue"}];
+            OCMVerify([adbMobileMock trackAction:@"Screen view" data:[OCMArg any]]);
+        });
+
+        it(@"Calls -trackState:data: for pageViews with additional parameters when configured to do so", ^{
+            [[adbMobileMock reject] trackAction:[OCMArg any] data:[OCMArg any]];
+
+            AdobeProvider *provider = [[AdobeProvider alloc] initWithData:@{} settings:@{
+                    AdobeProviderCallsTrackStateForPageViewsWithProperties : @YES
+            }];
+            [ARAnalytics setupProvider:provider];
+
+            [provider didShowNewPageView:@"page one" withProperties:@{@"color" : @"blue"}];
+            OCMVerify([adbMobileMock trackState:@"page one" data:[OCMArg isNotNil]]);
+        });
+
+    });
+
+SpecEnd

--- a/Providers/AdobeProvider.h
+++ b/Providers/AdobeProvider.h
@@ -1,7 +1,10 @@
 #import "ARAnalyticalProvider.h"
 
+extern NSString const *AdobeProviderCallsTrackStateForPageViewsWithProperties;
+
 @interface AdobeProvider : ARAnalyticalProvider
 
 - (id)initWithData:(NSDictionary *)additionalData;
+- (id)initWithData:(NSDictionary *)additionalData settings:(NSDictionary*)settings;
 
 @end

--- a/Providers/AdobeProvider.m
+++ b/Providers/AdobeProvider.m
@@ -31,5 +31,11 @@
                      data:nil];
 }
 
+- (void)didShowNewPageView:(NSString *)pageTitle withProperties:(NSDictionary *)properties {
+    [ADBMobile trackState:pageTitle
+                     data:properties];
+}
+
+
 #endif
 @end

--- a/Providers/AdobeProvider.m
+++ b/Providers/AdobeProvider.m
@@ -2,10 +2,27 @@
 #import "ARAnalyticsProviders.h"
 #import "ADBMobile.h"
 
+@interface AdobeProvider ()
+/**
+ * The default implementation for this provider is to track screens "-trackAction:data:" calls when they contain
+ * custom key/value properties in addition to the pageTitle. By setting this property to YES, the Adobe Provider
+ * will call "-trackState:data:" for page views that contain additional custom properties.
+ *
+ * The default value is NO.
+ */
+@property (nonatomic) BOOL callsTrackStateForPageViewsWithProperties;
+@end
+
+NSString const *AdobeProviderCallsTrackStateForPageViewsWithProperties = @"callsTrackStateForPageViewsWithProperties";
+
 @implementation AdobeProvider
 #ifdef AR_ADOBE_EXISTS
 
 - (id)initWithData:(NSDictionary *)additionalData {
+    return [self initWithData:additionalData settings:nil];
+}
+
+- (id)initWithData:(NSDictionary *)additionalData settings:(NSDictionary*)settings {
     NSAssert([ADBMobile class], @"Adobe is not included");
     if(additionalData) {
         [ADBMobile collectLifecycleDataWithAdditionalData:additionalData];
@@ -13,7 +30,11 @@
         [ADBMobile collectLifecycleData];
     }
 
-    return [super init];
+    self = [super init];
+    if (self) {
+        self.callsTrackStateForPageViewsWithProperties = [settings[AdobeProviderCallsTrackStateForPageViewsWithProperties] boolValue];
+    }
+    return self;
 }
 
 - (id)initWithIdentifier:(NSString *)identifier
@@ -32,8 +53,12 @@
 }
 
 - (void)didShowNewPageView:(NSString *)pageTitle withProperties:(NSDictionary *)properties {
-    [ADBMobile trackState:pageTitle
-                     data:properties];
+    if (self.callsTrackStateForPageViewsWithProperties) {
+        [ADBMobile trackState:pageTitle
+                        data:properties];
+    } else {
+        [super didShowNewPageView:pageTitle withProperties:properties];
+    }
 }
 
 


### PR DESCRIPTION
In our Omniture implementation, all screen views have custom properties associated with them. This PR overrides `-didShowNewPageView:withProperties:` to call `-trackState:data:` for page views that have custom context data. Without this PR, ARAnalytics triggers an event (`-trackAction:data:`). Is this something that would be useful to other developers? or is this too specific to our implementation? Thanks