### PR TITLE
Treat countly screen view as separate event not segment of screen_view

### DIFF
--- a/Providers/CountlyProvider.m
+++ b/Providers/CountlyProvider.m
@@ -22,5 +22,9 @@
     [[Countly sharedInstance] recordEvent:event segmentation:properties count:1];
 }
 
+- (void)didShowNewPageView:(NSString *)pageTitle withProperties:(NSDictionary *)properties {
+    [self event:pageTitle withProperties:properties];
+}
+
 #endif
 @end


### PR DESCRIPTION
Yet another change to `countly` provider.

Main motivation for this change:
1. Countly does not have separate notion of 'screen view'.
2. Default implementation of `ARAnalyticsProvider` does not quite work, because if you want to create a [funnel](http://resources.count.ly/docs/funnels) you won't be able to select particular screen as a funnel step -- Countly does not allow to select property of an event (in this case screen name) as a step.

Basically current implementation makes impossible to create funnels based solely on screens. Even though change looks like *breaking* I doubt anyone would feel bad on this because old data format is practically unusable (very IMHO here)


Proposed implementation treats every screen as a separate event and makes possible to create funnels.