### PR TITLE
Dynamic page/event names in DSL for screen tracking

### DIFF
--- a/ARDSL.h
+++ b/ARDSL.h
@@ -9,13 +9,27 @@ extern NSString * const ARAnalyticsClass;
 extern NSString * const ARAnalyticsDetails;
 extern NSString * const ARAnalyticsProperties;
 extern NSString * const ARAnalyticsPageName;
+extern NSString * const ARAnalyticsPageNameBlock;
 extern NSString * const ARAnalyticsPageNameKeyPath;
 extern NSString * const ARAnalyticsEventName;
+extern NSString * const ARAnalyticsEventNameBlock;
 extern NSString * const ARAnalyticsSelectorName;
 extern NSString * const ARAnalyticsEventProperties __attribute__((deprecated("Renamed to ARAnalyticsProperties")));
 extern NSString * const ARAnalyticsShouldFire;
 
+/**
+ * Optionally supply an NSDictionary of custom properties at the time a screen view or event is triggered. This is the
+ * value type used for the ARAnalyticsProperties key.
+ */
 typedef NSDictionary*(^ARAnalyticsPropertiesBlock)(id instance, NSArray *arguments);
+/**
+ * ARAnalyticsNameBlock is used to dynamically supply a pageName or eventName at the time the screen view or event/action
+ * is triggered. This is the value type used for the ARAnalyticsPageNameBlock or ARAnalyticsEventNameBlock keys.
+ *
+ * Often times, the tracked screen or event name is a derivative of the custom tracking parameters. The customProperties
+ * parameter contains the dictionary, if any, supplied by the ARAnalyticsProperties block
+ */
+typedef NSString*(^ARAnalyticsNameBlock)(id instance, NSArray *arguments, NSDictionary *customProperties);
 typedef ARAnalyticsPropertiesBlock ARAnalyticsEventPropertiesBlock __attribute__((deprecated("Renamed to ARAnalyticsPropertiesBlock")));
 
 typedef BOOL(^ARAnalyticsEventShouldFireBlock)(id instance, NSArray *arguments);

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # ARAnalytics
 
+## Version 3.9.1
+* Add support for dynamic page names and event names in the DSL (@arifken)
+
 ## Version 3.9.0
 
 * Adds MobileAppTracker/Tune support (@fabiojgrocha)

--- a/Example/ARAnalyticsiOSTests/ARAnalyticsDSLTests.m
+++ b/Example/ARAnalyticsiOSTests/ARAnalyticsDSLTests.m
@@ -92,17 +92,14 @@ describe(@"events", ^{
 
     beforeEach(^{
         event = [[NSUUID UUID] UUIDString];
-        analyticsMock = [OCMockObject mockForClass:ARAnalytics.class];
+        analyticsMock = OCMClassMock([ARAnalytics class]);
     });
 
     afterEach(^{
-        [analyticsMock verify];
         [analyticsMock stopMocking];
     });
 
     it(@"calls the event method on ARAnalytics after the method", ^{
-        [[analyticsMock expect] event:event withProperties:OCMOCK_ANY];
-        
         [ARAnalytics addEventAnalyticsHook: @{
             ARAnalyticsClass: TestObject.class,
             ARAnalyticsDetails: @[@{
@@ -110,16 +107,31 @@ describe(@"events", ^{
                 ARAnalyticsSelectorName: ARAnalyticsSelector(methodToBeExecuted),
             }]
         }];
-        
+
         [[[TestObject alloc] init] methodToBeExecuted];
+
+        OCMVerify([analyticsMock event:event withProperties:[OCMArg any]]);
+    });
+
+    it(@"calls the event method on ARAnalytics after the method when the event name is supplied via a block", ^{
+        [ARAnalytics addEventAnalyticsHook:@{
+                ARAnalyticsClass : TestObject.class,
+                ARAnalyticsDetails : @[@{
+                        ARAnalyticsEventNameBlock : ^NSString *(TestObject *controller,
+                                NSArray *parameters, NSDictionary *customProperties) {
+                            return event;
+                        },
+                        ARAnalyticsSelectorName : ARAnalyticsSelector(methodToBeExecuted),
+                }]
+        }];
+
+        [[[TestObject alloc] init] methodToBeExecuted];
+
+        OCMVerify([analyticsMock event:event withProperties:[OCMArg any]]);
     });
 
     it(@"respects the properties given by ARAnalyticsEventProperties", ^{
         NSString *propertyKey = @"airplanes";
-
-        [[analyticsMock expect] event:event withProperties:[OCMArg checkWithBlock:^BOOL(NSDictionary *properties) {
-            return properties[propertyKey] != nil;
-        }]];
 
         [ARAnalytics addEventAnalyticsHook: @{
             ARAnalyticsClass: TestObject.class,
@@ -133,6 +145,10 @@ describe(@"events", ^{
         }];
 
         [[[TestObject alloc] init] methodToBeExecutedWithProperties];
+
+        OCMVerify([analyticsMock event:event withProperties:[OCMArg checkWithBlock:^BOOL(NSDictionary *properties) {
+            return properties[propertyKey] != nil;
+        }]]);
     });
 
     describe(@"should fire", ^{
@@ -162,10 +178,11 @@ describe(@"events", ^{
             }];
             
             [[[TestObject alloc] init] methodToBeSkipped];
+
+            OCMVerifyAll(analyticsMock);
         });
 
         it(@"fires event when shouldFire = YES", ^{
-            [[analyticsMock expect] event:event withProperties:OCMOCK_ANY];
 
             [ARAnalytics addEventAnalyticsHook: @{
                 ARAnalyticsClass: TestObject.class,
@@ -180,6 +197,8 @@ describe(@"events", ^{
             }];
 
             [[[TestObject alloc] init] methodToNotBeSkipped];
+
+            OCMVerify([analyticsMock event:event withProperties:OCMOCK_ANY]);
         });
 
     });
@@ -206,6 +225,24 @@ describe(@"tracking screens", ^{
             }]
         }];
         
+        [[[TestObject alloc] init] appearedMethod];
+
+        expect(provider.lastEventName).to.equal(@"Screen view");
+        expect(provider.lastEventProperties).to.equal(@{ @"screen": @"page"});
+    });
+
+    it(@"tracks page views with the page name supplied from a block", ^{
+        [ARAnalytics addScreenMonitoringAnalyticsHook: @{
+            ARAnalyticsClass: TestObject.class,
+            ARAnalyticsDetails: @[ @{
+                ARAnalyticsPageNameBlock: ^NSString *(UIViewController *controller, NSArray *parameters,
+                                                    NSDictionary *customProperties) {
+                            return @"page";
+                },
+                ARAnalyticsSelectorName: ARAnalyticsSelector(appearedMethod),
+            }]
+        }];
+
         [[[TestObject alloc] init] appearedMethod];
 
         expect(provider.lastEventName).to.equal(@"Screen view");

--- a/Example/Podfile
+++ b/Example/Podfile
@@ -10,5 +10,5 @@ end
 target "ARAnalyticsiOSTests" do
   pod 'Specta', '~> 1'
   pod 'Expecta', '~> 0.2'
-  pod 'OCMock', '2.2.4'
+  pod 'OCMock', '3.2.1'
 end

--- a/Example/Podfile.lock
+++ b/Example/Podfile.lock
@@ -1,14 +1,14 @@
 PODS:
-  - ARAnalytics/CoreIOS (3.8.1)
-  - ARAnalytics/DSL (3.8.1):
+  - ARAnalytics/CoreIOS (3.9.0)
+  - ARAnalytics/DSL (3.9.0):
     - ReactiveCocoa (~> 2.0)
     - RSSwizzle (~> 0.1.0)
-  - ARAnalytics/Intercom (3.8.1):
+  - ARAnalytics/Intercom (3.9.0):
     - ARAnalytics/CoreIOS
     - Intercom
   - Expecta (0.4.2)
-  - Intercom (2.3.16)
-  - OCMock (2.2.4)
+  - Intercom (2.3.18)
+  - OCMock (3.2.1)
   - ReactiveCocoa (2.5):
     - ReactiveCocoa/UI (= 2.5)
   - ReactiveCocoa/Core (2.5):
@@ -23,7 +23,7 @@ DEPENDENCIES:
   - ARAnalytics/DSL (from `../`)
   - ARAnalytics/Intercom (from `../`)
   - Expecta (~> 0.2)
-  - OCMock (= 2.2.4)
+  - OCMock (= 3.2.1)
   - Specta (~> 1)
 
 EXTERNAL SOURCES:
@@ -31,12 +31,14 @@ EXTERNAL SOURCES:
     :path: ../
 
 SPEC CHECKSUMS:
-  ARAnalytics: 2d3ab0af06af77e85307236bb12bf83622c50a96
+  ARAnalytics: 187eda288065f6810044931540ee194bbe466e70
   Expecta: 78b4e8b0c8291fa4524d7f74016b6065c2e391ec
-  Intercom: 296dfb41c92ff90de23adb1d975d337aa9dd422f
-  OCMock: a6a7dc0e3997fb9f35d99f72528698ebf60d64f2
+  Intercom: 1d2f2c9fd6bbb292a82640e710ca156133a1ae8c
+  OCMock: f9622770761b680e505f893885780d369ae30016
   ReactiveCocoa: e2db045570aa97c695e7aa97c2bcab222ae51f4a
   RSSwizzle: d561958f595028bfcef98c7d55c318b3878a61c6
   Specta: ac94d110b865115fe60ff2c6d7281053c6f8e8a2
 
-COCOAPODS: 0.39.0
+PODFILE CHECKSUM: 91095da67601ba14a9506e575e6eb821e54364bb
+
+COCOAPODS: 1.0.0.beta.2

--- a/README.md
+++ b/README.md
@@ -110,21 +110,34 @@ There is also a DSL-like setup constructor in the `ARAnalytics/DSL` subspec that
    ...
 ```
 
-The above configuration specifies that the "button pressed" event be sent whenever the selector `buttonPressed:` is invoked on *any* instance of `MyViewController`. Additionally, every view controller will send a page view with its title as the page name whenever `viewDidAppear:` is called. There are also advanced uses using blocks in the DSL to selectively disable certain events, or to provide event property dictionaries.
+The above configuration specifies that the "button pressed" event be sent whenever the selector `buttonPressed:` is invoked on *any* instance of `MyViewController`. Additionally, every view controller will send a page view with its title as the page name whenever `viewDidAppear:` is called. There are also advanced uses using blocks in the DSL to selectively disable certain events, provide custom page/event property dictionaries, or to provide dynamic page/event names. 
 
 ```objc
 [ARAnalytics setupWithAnalytics: @{ /* keys */ } configuration: @{
+   ARAnalyticsTrackedScreens: @[ @{
+      ARAnalyticsClass: UIViewController.class,
+      ARAnalyticsDetails: @[ @{
+          ARAnalyticsProperties: ^NSDictionary*(MyViewController *controller, NSArray *parameters) {
+            return @{ /* Custom screen view properties */ };
+          }, 
+          ARAnalyticsPageNameBlock:  ^NSDictionary*(MyViewController *controller, NSArray *parameters, NSDictionary *customProperties) {
+            return [NSString stringWithFormat:@"%@:%@:%@",controller.a, controller.b, controller.c];
+          }
+      }]
+  }],
   ARAnalyticsTrackedEvents: @[ @{
     ARAnalyticsClass: MyViewController.class,
     ARAnalyticsDetails: @[ 
       @{
-        ARAnalyticsEventName: @"button pressed",
         ARAnalyticsSelectorName: NSStringFromSelector(@selector(buttonPressed:)),
         ARAnalyticsShouldFire: ^BOOL(MyViewController *controller, NSArray *parameters) {
           return /* some condition */;
         },
-        ARAnalyticsEventProperties: ^NSDictionary*(MyViewController *controller, NSArray *parameters) {
+        ARAnalyticsProperties: ^NSDictionary*(MyViewController *controller, NSArray *parameters) {
           return @{ /* Custom properties */ };
+        },
+        ARAnalyticsEventNameBlock:  ^NSDictionary*(MyViewController *controller, NSArray *parameters, NSDictionary *customProperties) {
+          return [NSString stringWithFormat:@"%@ pressed", [(UIButton*)parameters[0] titleLabel].text];
         }
       },
       /* more events for this class */


### PR DESCRIPTION
Revised version of https://github.com/orta/ARAnalytics/pull/246

In our analytics implementation, the page name for screen views (as well as the event names for actions) can only be derived at the time when the screen view is triggered. This PR allows the developer to optionally return the page name and event name from block parameters passed in the ARAnalytics setup dictionary.