### PR TITLE
Use proper error logging method for Fabric / Crashlytics

### DIFF
--- a/Providers/CrashlyticsProvider.h
+++ b/Providers/CrashlyticsProvider.h
@@ -12,6 +12,8 @@
 - (void)setUserName:(NSString *)name;
 - (void)setUserEmail:(NSString *)email;
 - (void)setObjectValue:(id)value forKey:(NSString *)key;
+- (void)setObjectValue:(id)value forKey:(NSString *)key;
+- (void)recordError:(NSError *)error withAdditionalUserInfo:(NSDictionary *)userInfo;
 @end
 
 OBJC_EXTERN void CLSLog(NSString *format, ...) NS_FORMAT_FUNCTION(1,2);

--- a/Providers/CrashlyticsProvider.h
+++ b/Providers/CrashlyticsProvider.h
@@ -12,7 +12,6 @@
 - (void)setUserName:(NSString *)name;
 - (void)setUserEmail:(NSString *)email;
 - (void)setObjectValue:(id)value forKey:(NSString *)key;
-- (void)setObjectValue:(id)value forKey:(NSString *)key;
 - (void)recordError:(NSError *)error withAdditionalUserInfo:(NSDictionary *)userInfo;
 @end
 

--- a/Providers/CrashlyticsProvider.m
+++ b/Providers/CrashlyticsProvider.m
@@ -43,5 +43,9 @@
     CLSLog(@"%@", parsedString);
 }
 
+- (void)error:(NSError *)error withMessage:(NSString *)message {
+    [[Crashlytics sharedInstance] recordError:error withAdditionalUserInfo:@{@"message": message}];
+}
+
 #endif
 @end

--- a/Providers/FabricProvider.m
+++ b/Providers/FabricProvider.m
@@ -6,6 +6,7 @@
 - (void)setUserName:(NSString *)name;
 - (void)setUserEmail:(NSString *)email;
 - (void)setObjectValue:(id)value forKey:(NSString *)key;
+- (void)recordError:(NSError *)error withAdditionalUserInfo:(NSDictionary *)userInfo;
 @end
 
 #ifndef ANS_GENERIC
@@ -103,6 +104,11 @@ NS_ASSUME_NONNULL_END
 
 - (void)remoteLog:(NSString *)parsedString {
     CLSLog(@"%@", parsedString);
+}
+
+
+- (void)error:(NSError *)error withMessage:(NSString *)message {
+    [[Crashlytics sharedInstance] recordError:error withAdditionalUserInfo:@{@"message": message}];
 }
 
 #endif


### PR DESCRIPTION
Crashlytics v3.5.0 provides more specialized method for error logging: https://docs.fabric.io/ios/crashlytics/logged-errors.html so we should replace default fallback to log errors as custom events.