### PR TITLE
Fixed issue in DSL where properties block was being invoked more than once

### DIFF
--- a/ARDSL.m
+++ b/ARDSL.m
@@ -79,21 +79,21 @@ ARExtractProperties(id object, NSDictionary *analyticsEntry, RACTuple *parameter
 }
 
 static NSString *
-ARExtractPageName(id object, NSDictionary *analyticsEntry, RACTuple *parameters)
+ARExtractPageName(id object, NSDictionary *analyticsEntry, RACTuple *parameters, NSDictionary *extractedProperties)
 {
     ARAnalyticsNameBlock pageNameBlock = analyticsEntry[ARAnalyticsPageNameBlock];
     if (pageNameBlock) {
-        return pageNameBlock(object, parameters.allObjects, ARExtractProperties(object, analyticsEntry, parameters));
+        return pageNameBlock(object, parameters.allObjects, extractedProperties);
     }
     return nil;
 }
 
 static NSString *
-ARExtractEventName(id object, NSDictionary *analyticsEntry, RACTuple *parameters)
+ARExtractEventName(id object, NSDictionary *analyticsEntry, RACTuple *parameters, NSDictionary *extractedProperties)
 {
     ARAnalyticsNameBlock eventNameBlock = analyticsEntry[ARAnalyticsEventNameBlock];
     if (eventNameBlock) {
-        return eventNameBlock(object, parameters.allObjects, ARExtractProperties(object, analyticsEntry, parameters));
+        return eventNameBlock(object, parameters.allObjects, extractedProperties);
     }
     return nil;
 }
@@ -117,11 +117,13 @@ ARExtractEventName(id object, NSDictionary *analyticsEntry, RACTuple *parameters
 
                 if (shouldFire) {
                     NSString *eventName = event;
+                    NSDictionary *properties = ARExtractProperties(instance, object, parameters);
+
                     if (!eventName) {
                         // if the event name was not set statically, see if it's available via the block parameter
-                        eventName = ARExtractEventName(instance, object, parameters);
+                        eventName = ARExtractEventName(instance, object, parameters, properties);
                     }
-                    [ARAnalytics event:eventName withProperties:ARExtractProperties(instance, object, parameters)];
+                    [ARAnalytics event:eventName withProperties:properties];
                 }
             }];
         }];
@@ -153,6 +155,8 @@ ARExtractEventName(id object, NSDictionary *analyticsEntry, RACTuple *parameters
 
                 if (shouldFire) {
                     NSString *pageName;
+                    NSDictionary *properties = ARExtractProperties(instance, object, parameters);
+
                     if (dictionaryPageName) {
                         pageName = dictionaryPageName;
                     } else if (pageNameKeypath) {
@@ -160,13 +164,12 @@ ARExtractEventName(id object, NSDictionary *analyticsEntry, RACTuple *parameters
                         NSAssert(pageName, @"Value for Key on `%@` returned nil.", pageNameKeypath);
                     } else {
                         // if we still don't have a page name, check to see if it is supplied dynamically
-                        pageName = ARExtractPageName(instance, object, parameters);
+                        pageName = ARExtractPageName(instance, object, parameters, properties);
                     }
 
                     // Because of backwards compatibility we can't currently expect
                     // `-[ARAnalyticsProvider pageView:withProperties:]` to call existing
                     // `-[ARAnalyticsProvider pageView:]` implementations, so call the right one.
-                    NSDictionary *properties = ARExtractProperties(instance, object, parameters);
                     if (properties) {
                         [ARAnalytics pageView:pageName withProperties:properties];
                     } else {

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # ARAnalytics
 
+## Version 3.9.2
+* Fix issue in DSL where properties block was being invoked more than once (@arifken)
+
 ## Version 3.9.1
 * Add support for dynamic page names and event names in the DSL (@arifken)
 * Add configuration setting to the Adobe provider for -trackAction:data: vs. -trackState:data: for screen views. When enabled, allows page views with custom properties to be tracked with -trackState:data: (@arifken)

--- a/Example/ARAnalyticsiOSTests/ARAnalyticsDSLTests.m
+++ b/Example/ARAnalyticsiOSTests/ARAnalyticsDSLTests.m
@@ -129,6 +129,29 @@ describe(@"events", ^{
 
         OCMVerify([analyticsMock event:event withProperties:[OCMArg any]]);
     });
+    
+    it(@"only calls the block to extract properties once", ^{
+        __block NSInteger timesCalled = 0;
+        [ARAnalytics addEventAnalyticsHook:@{
+                ARAnalyticsClass : TestObject.class,
+                ARAnalyticsDetails : @[@{
+                       ARAnalyticsProperties: ^NSDictionary*(TestObject *controller, NSArray *parameters) {
+                            timesCalled++;
+                            return @{};
+                       },
+                       ARAnalyticsEventNameBlock : ^NSString *(TestObject *controller,
+                                                      NSArray *parameters, NSDictionary *customProperties) {
+                            return event;
+                       },
+                       ARAnalyticsSelectorName : ARAnalyticsSelector(methodToBeExecuted),
+                }]
+        }];
+        
+        [[[TestObject alloc] init] methodToBeExecuted];
+        
+        OCMVerify([analyticsMock event:event withProperties:[OCMArg any]]);
+        expect(timesCalled).to.equal(1);
+    });
 
     it(@"respects the properties given by ARAnalyticsEventProperties", ^{
         NSString *propertyKey = @"airplanes";


### PR DESCRIPTION
In cases where we supply a block for a page name or event name, the properties block was getting invoked twice. This fixes it so that the properties only get extracted once per screen view or event.