### PR TITLE
Dispatch GA right away while debugging

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # ARAnalytics
 
+## Master
+
+* Add Google Analytics event dispatching immediately after sending events while debugging (@superarts)
+
 ## Version 3.9.2
 * Fix issue in DSL where properties block was being invoked more than once (@arifken)
 

--- a/Providers/GoogleAnalyticsProvider.m
+++ b/Providers/GoogleAnalyticsProvider.m
@@ -59,7 +59,7 @@
         category = @"default"; // category is a required value
     }
 
-    [self.tracker send:[self finalizedPropertyDictionaryFromBuilder:[GAIDictionaryBuilder
+    [self send:[self finalizedPropertyDictionaryFromBuilder:[GAIDictionaryBuilder
                                                                      createEventWithCategory:category
                                                                      action:event
                                                                      label:properties.label
@@ -92,7 +92,7 @@
         builder = [GAIDictionaryBuilder createAppView];
 #pragma clang diagnostic pop
     }
-    [self.tracker send:[self finalizedPropertyDictionaryFromBuilder:builder withProperties:properties]];
+    [self send:[self finalizedPropertyDictionaryFromBuilder:builder withProperties:properties]];
 }
 
 - (void)logTimingEvent:(NSString *)event withInterval:(NSNumber *)interval properties:(NSDictionary *)properties {
@@ -113,7 +113,7 @@
                                                                           interval:@((int)([interval doubleValue]*1000))
                                                                               name:event
                                                                              label:nil];
-    [self.tracker send:[self finalizedPropertyDictionaryFromBuilder:builder withProperties:properties]];
+    [self send:[self finalizedPropertyDictionaryFromBuilder:builder withProperties:properties]];
 }
 
 - (NSMutableDictionary *)finalizedPropertyDictionaryFromBuilder:(GAIDictionaryBuilder *)builder
@@ -149,6 +149,14 @@
     [[GAI sharedInstance] dispatch];
 }
 
+- (void)send:(NSDictionary *)parameters {
+	[self.tracker send:parameters];
+	//	send events immediately while debugging
+#ifdef DEBUG
+	[self dispatchGA];
+#endif
+}
+
 #pragma mark - Warnings
 
 - (void)warnAboutIgnoredProperties:(NSDictionary*)propertiesDictionary {
@@ -164,4 +172,5 @@
 }
 
 #endif
+
 @end


### PR DESCRIPTION
Google Analytics doesn't dispatch tracking events by default. While this makes perfect sense in production, it would be convenient to see real time events come through. So I added a little bit piece of code to dispatch GA events if it's a `DEBUG` build.

In the other hand, if you don't think it's a good idea to make it a default behaviour, I'd like to comment here that we can always call `dispatchGA` manually after a `	[ARAnalytics event:]` call.

```
GoogleAnalyticsProvider *gaProvider =
	(GoogleAnalyticsProvider *)[ARAnalytics providerInstanceOfClass:[GoogleAnalyticsProvider class]];
[gaProvider dispatchGA];
```
