### PR TITLE
Suppress intercom warnings

### DIFF
--- a/Providers/IntercomProvider.m
+++ b/Providers/IntercomProvider.m
@@ -19,8 +19,14 @@
     // Use ARAnalytics providerInstanceOfClass:IntercomProvider
     // to turn this off if you're getting too many events
 
-    if (self.registerTrackedEvents) {
+    if (!self.registerTrackedEvents) {
+        return;
+    }
+
+    if (properties && properties.count > 0) {
         [Intercom logEventWithName:event metaData:properties];
+    } else {
+        [Intercom logEventWithName:event];
     }
 }
 


### PR DESCRIPTION
Intercom's internal implementation does not like if you pass empty dictionaries:
```
 [Intercom] ERROR - 'metaData' parameter must be an NSDictionary and can't be nil or empty
```
so we check for it on the provider level and decide which API to use.