### PR TITLE
Added Firebase

### DIFF
--- a/ARAnalytics.h
+++ b/ARAnalytics.h
@@ -56,6 +56,7 @@
 + (void)setupMixpanelWithToken:(NSString *)token andHost:(NSString *)host;
 + (void)setupFlurryWithAPIKey:(NSString *)key;
 + (void)setupGoogleAnalyticsWithID:(NSString *)identifier;
++ (void)setupFirebaseAnalytics;
 + (void)setupLocalyticsWithAppKey:(NSString *)key;
 + (void)setupKISSMetricsWithAPIKey:(NSString *)key;
 + (void)setupCrittercismWithAppID:(NSString *)appID;

--- a/ARAnalytics.m
+++ b/ARAnalytics.m
@@ -297,6 +297,14 @@ static BOOL _ARLogShouldPrintStdout = YES;
 #endif
 }
 
++ (void)setupFirebaseAnalytics
+{
+#ifdef AR_FIREBASE_EXISTS
+    FirebaseProvider *provider = [[FirebaseProvider alloc] initWithIdentifier:nil];
+    [self setupProvider:provider];
+#endif
+}
+
 + (void)setupLocalyticsWithAppKey:(NSString *)key
 {
 #ifdef AR_LOCALYTICS_EXISTS

--- a/ARAnalytics.podspec
+++ b/ARAnalytics.podspec
@@ -47,6 +47,7 @@ Pod::Spec.new do |s|
   appsee           = { :spec_name => "Appsee",              :dependency => "Appsee" }
   mobileapptracker = { :spec_name => "MobileAppTracker",    :dependency => "MobileAppTracker"}
   launchkit        = { :spec_name => "LaunchKit",           :dependency => "LaunchKit" }
+  firebase         = { :spec_name => "Firebase",            :dependency => "Firebase/Core" }
 
   kissmetrics_mac = { :spec_name => "KISSmetricsOSX",  :dependency => "KISSmetrics",            :osx => true,  :provider => "KISSmetrics" }
 # countly_mac     = { :spec_name => "CountlyOSX",      :dependency => "Countly",                :osx => true,  :provider => "Countly" }
@@ -55,7 +56,7 @@ Pod::Spec.new do |s|
   parseAnalytics_mac = { :spec_name => "ParseAnalyticsOSX", :dependency => "Parse",             :osx => true,  :provider => "ParseAnalytics", :has_extension => true }
 
 
-  all_analytics = [mixpanel, localytics, flurry, google, kissmetrics, crittercism, crashlytics, fabric, bugsnag, countly, helpshift, kissmetrics_mac, mixpanel_mac, tapstream, newRelic, amplitude, hockeyApp, hockeyAppLib, hockeyApp_mac, parseAnalytics, parseAnalytics_mac, heap, chartbeat, umeng, librato, segmentio, swrve, yandex, adjust, appsflyer, branch, snowplow, sentry, intercom, keen, adobe, installtracker, appsee, mobileapptracker, launchkit]
+  all_analytics = [mixpanel, localytics, flurry, google, kissmetrics, crittercism, crashlytics, fabric, bugsnag, countly, helpshift, kissmetrics_mac, mixpanel_mac, tapstream, newRelic, amplitude, hockeyApp, hockeyAppLib, hockeyApp_mac, parseAnalytics, parseAnalytics_mac, heap, chartbeat, umeng, librato, segmentio, swrve, yandex, adjust, appsflyer, branch, snowplow, sentry, intercom, keen, adobe, installtracker, appsee, mobileapptracker, launchkit, firebase]
 
   # To make the pod spec API cleaner, subspecs are "iOS/KISSmetrics"
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Master
 
 * Add Google Analytics event dispatching immediately after sending events while debugging (@superarts)
+* Added support for Firebase Analytics (@BenchR267)
 
 ## Version 3.9.2
 * Fix issue in DSL where properties block was being invoked more than once (@arifken)

--- a/Providers/ARAnalyticsProviders.h
+++ b/Providers/ARAnalyticsProviders.h
@@ -19,6 +19,10 @@
 #import "ARAnalytics+GoogleAnalytics.h"
 #endif
 
+#ifdef AR_FIREBASE_EXISTS
+#import "FirebaseProvider.h"
+#endif
+
 #ifdef AR_KISSMETRICS_EXISTS
 #import "KISSmetricsProvider.h"
 #endif

--- a/Providers/FirebaseProvider.h
+++ b/Providers/FirebaseProvider.h
@@ -1,0 +1,5 @@
+#import "ARAnalyticalProvider.h"
+
+@interface FirebaseProvider : ARAnalyticalProvider
+
+@end

--- a/Providers/FirebaseProvider.m
+++ b/Providers/FirebaseProvider.m
@@ -1,0 +1,50 @@
+#import "FirebaseProvider.h"
+#import "ARAnalyticsProviders.h"
+#import <Firebase/Firebase.h>
+
+@implementation FirebaseProvider
+#ifdef AR_FIREBASE_EXISTS
+
+- (id)initWithIdentifier:(NSString *)identifier {
+    NSAssert([FIRApp class], @"Firebase SDK is not included");
+    NSAssert([FIRAnalytics class], @"Firebase SDK is not included");
+
+    if ((self = [super init])) {
+        [FIRApp configure];
+    }
+
+    return self;
+}
+
+- (void)identifyUserWithID:(NSString *)userID andEmailAddress:(NSString *)email {
+    [FIRAnalytics setUserID:userID];
+}
+
+- (void)setUserProperty:(NSString *)property toValue:(id)value {
+
+    if (![value isKindOfClass:[NSString class]])
+    {
+        NSLog(@"Tried to log user property %@ for property name %@, but value is no NSString. Only NSString values are supported by Firebase Analytics.", value, property);
+    }
+
+    NSString *stringValue = ((NSString *)value);
+    [FIRAnalytics setUserPropertyString:stringValue forName:property];
+}
+
+- (void)event:(NSString *)event withProperties:(NSDictionary *)properties {
+    [FIRAnalytics logEventWithName:event parameters:properties];
+}
+
+- (void)didShowNewPageView:(NSString *)pageTitle {
+    [self didShowNewPageView:pageTitle withProperties:nil];
+}
+
+- (void)didShowNewPageView:(NSString *)pageTitle withProperties:(NSDictionary *)properties {
+
+    // Firebase Analytics does not offer a functionality for page views, so they are tracked as events
+    [self event:pageTitle withProperties:properties];
+}
+
+#endif
+
+@end

--- a/README.md
+++ b/README.md
@@ -165,7 +165,7 @@ Note, however, that on iOS `syslogd` will not keep logs around for a long time, 
 Full list of subspecs
 ----
 
-iOS: `Mixpanel`, `Localytics`, `Flurry`, `GoogleAnalytics`, `KISSmetrics`, `Crittercism`, `Countly`, `Bugsnag`, `Helpshift`, `Tapstream`, `NewRelic`, `Amplitude`, `HockeyApp`, `HockeyAppLib`, `ParseAnalytics`, `HeapAnalytics`, `Chartbeat`, `UMengAnalytics`, `Segmentio`, `Swrve`, `YandexMobileMetrica`, `Adjust`, `Intercom`, `Librato`, `Crashlytics`, `Fabric`, `AppsFlyer`, `Branch`, `Snowplow`, `Sentry`, `Keen`, `Adobe` & `MobileAppTracker`.
+iOS: `Mixpanel`, `Localytics`, `Flurry`, `GoogleAnalytics`, `Firebase`, `KISSmetrics`, `Crittercism`, `Countly`, `Bugsnag`, `Helpshift`, `Tapstream`, `NewRelic`, `Amplitude`, `HockeyApp`, `HockeyAppLib`, `ParseAnalytics`, `HeapAnalytics`, `Chartbeat`, `UMengAnalytics`, `Segmentio`, `Swrve`, `YandexMobileMetrica`, `Adjust`, `Intercom`, `Librato`, `Crashlytics`, `Fabric`, `AppsFlyer`, `Branch`, `Snowplow`, `Sentry`, `Keen`, `Adobe` & `MobileAppTracker`.
 
 OSX: `KISSmetricsOSX`, `HockeyAppOSX`, `MixpanelOSX` & `ParseAnalyticsOSX`.
 


### PR DESCRIPTION
This is a first implementation for https://github.com/orta/ARAnalytics/issues/267. There might be some more implementation needed for some cases (set a custom app name e.g.) which can be added later. This supports logging events and page views to Firebase (which does not support page views, so page views are normal events as well).
This also adds the functionality to log user properties and the userID to Firebase.