### PR TITLE
Add ARLogv, non-variadic version of ARLog, for Swift interop.

### DIFF
--- a/ARAnalytics.h
+++ b/ARAnalytics.h
@@ -170,6 +170,7 @@
 
 /// an NSLog-like command that send to providers
 extern void ARLog (NSString *format, ...) NS_FORMAT_FUNCTION(1,2);
+extern void ARLogv (NSString *format, va_list argList) NS_FORMAT_FUNCTION(1,0);
 
 /// A try-catch for nil protection wrapped event
 extern void ARAnalyticsEvent (NSString *event, NSDictionary *properties);

--- a/ARAnalytics.m
+++ b/ARAnalytics.m
@@ -759,18 +759,20 @@ static BOOL _ARLogShouldPrintStdout = YES;
 @end
 
 void ARLog (NSString *format, ...) {
+    va_list argList;
+    va_start(argList, format);
+    ARLogv(format, argList);
+    va_end(argList);
+}
+
+void ARLogv(NSString *format, va_list argList) {
     if (format == nil) {
         if (_ARLogShouldPrintStdout) {
             printf("nil \n");
         }
         return;
     }
-    // Get a reference to the arguments that follow the format parameter
-    va_list argList;
-    va_start(argList, format);
-
-    // Perform format string argument substitution, reinstate %% escapes, then print
-
+    
     @autoreleasepool {
         NSString *parsedFormatString = [[NSString alloc] initWithFormat:format arguments:argList];
         parsedFormatString = [parsedFormatString stringByReplacingOccurrencesOfString:@"%%" withString:@"%%%%"];
@@ -782,8 +784,6 @@ void ARLog (NSString *format, ...) {
             [provider remoteLog:parsedFormatString];
         }];
     }
-
-    va_end(argList);
 }
 
 void ARAnalyticsEvent (NSString *event, NSDictionary *properties) {

--- a/ARAnalytics.m
+++ b/ARAnalytics.m
@@ -765,7 +765,7 @@ void ARLog (NSString *format, ...) {
     va_end(argList);
 }
 
-void ARLogv(NSString *format, va_list argList) {
+void ARLogv (NSString *format, va_list argList) {
     if (format == nil) {
         if (_ARLogShouldPrintStdout) {
             printf("nil \n");

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Master
 
+* Added ARLogv function for Switft interop (@ibrt)
 * Changed import method for Localytics (@cemaleker)
 * changed return type of init methods to instancetype instead of id (@BenchR267)
 * Added support for Appboy (@BenchR267)


### PR DESCRIPTION
ARLog cannot be called from Swift code because variadic ObjC functions are not supported by the interop layer. I did some research and this seems to be the standard way to go about it (see for example the implementation of NSLog and NSLogv).