### PR TITLE
Convert id value into an NSString for Adjust

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Master
 
+* Fixes issue where Adjust SDK assumes event value is a string
 * Enables unidentified users for Intercom (@MrAlek)
 * Increased deployment target for Localytics and Intercom to 8.0 (@BenchR267 & @garnett)
 

--- a/Providers/AdjustProvider.m
+++ b/Providers/AdjustProvider.m
@@ -41,6 +41,14 @@
     ADJEvent *const adjustEvent = [ADJEvent eventWithEventToken:event];
 
     [properties enumerateKeysAndObjectsUsingBlock:^(id key, id value, BOOL *stop) {
+        // Adjust assumes value is a string, so if it's not convert it to a string value
+        if (![value isKindOfClass:[NSString class]]) {
+            if ([value respondsToSelector:@selector(stringValue)]) {
+                value = [value stringValue];
+            } else {
+                value = [value description];
+            }
+        }
         [adjustEvent addCallbackParameter:key value:value];
     }];
 


### PR DESCRIPTION
Adjust assumes `id value` is a string, so first try to convert it to a `stringValue` (`NSNumber`), otherwise, use the `description`.

This fixes a crash I was having where Adjust SDK was trying `isEmpty` on `value`.