### PR TITLE
Set category when logging timing events in GoogleAnalytics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 * Fixes issue where Adjust SDK assumes event value is a string
 * Enables unidentified users for Intercom (@MrAlek)
 * Increased deployment target for Localytics and Intercom to 8.0 (@BenchR267 & @garnett)
+* Updated logTimingEvent function to use given category for GoogleAnalytics. (@Goharhovhannisyan)
 
 ## Version 3.10.2
 

--- a/Providers/GoogleAnalyticsProvider.m
+++ b/Providers/GoogleAnalyticsProvider.m
@@ -109,7 +109,7 @@
     [self event:event withProperties:properties];
     
     // By Google's header, the interval should be seconds in milliseconds.
-    GAIDictionaryBuilder *builder = [GAIDictionaryBuilder createTimingWithCategory:@"default"
+    GAIDictionaryBuilder *builder = [GAIDictionaryBuilder createTimingWithCategory:properties.category ?: @"default"
                                                                           interval:@((int)([interval doubleValue]*1000))
                                                                               name:event
                                                                              label:nil];


### PR DESCRIPTION
This is the wanted change from https://github.com/orta/ARAnalytics/pull/286 and https://github.com/orta/ARAnalytics/pull/287.