### PR TITLE
Remove redundant definition of declared_trivial from Dangerfile #trivial

### DIFF
--- a/Dangerfile
+++ b/Dangerfile
@@ -1,6 +1,6 @@
 # Sometimes it's a README fix, or something like that - which isn't relevant for
 # including in a project's CHANGELOG for example
-declared_trivial = pr_title.include? "#trivial"
+declared_trivial = (pr_title + pr_body).include?("#trivial")
 
 # Make it more obvious that a PR is a work in progress and shouldn't be merged yet
 warn("PR is classed as Work in Progress") if pr_title.include? "[WIP]"
@@ -8,7 +8,6 @@ warn("PR is classed as Work in Progress") if pr_title.include? "[WIP]"
 # Warn when there is a big PR
 warn("Big PR") if lines_of_code > 500
 
-declared_trivial = (pr_title + pr_body).include?("#trivial")
 if !modified_files.include?("CHANGELOG.md") && !declared_trivial
   fail("Please include a CHANGELOG entry. \nYou can find it at [CHANGELOG.md](https://github.com/orta/ARAnalytics/blob/master/CHANGELOG.md).")
 end


### PR DESCRIPTION
declared_trivial was defined twice, but only used after the second initialization, so I moved the second one up and deleted the first one.