### PR TITLE
Makes Intercom reset old user data before registering user

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 * Enables unidentified users for Intercom (@MrAlek)
 * Increased deployment target for Localytics and Intercom to 8.0 (@BenchR267 & @garnett)
 * Updated logTimingEvent function to use given category for GoogleAnalytics. (@Goharhovhannisyan)
+* Makes Intercom reset old user data before registering user (@MrAlek)
 
 ## Version 3.10.2
 

--- a/Providers/IntercomProvider.m
+++ b/Providers/IntercomProvider.m
@@ -32,6 +32,8 @@
 
 - (void)identifyUserWithID:(NSString *)userID andEmailAddress:(NSString *)email
 {
+    [Intercom reset];
+    
     if (email) {
         [Intercom registerUserWithUserId:userID email:email];
     } else if (userID) {


### PR DESCRIPTION
Fixes issue of old Intercom data being left hanging after logging out or switching user. Without this, I would still see the same conversations after switching users, even after app restarts.

From Intercom SDK documentation:

> reset is used to reset all local caches and user data Intercom has created. Reset will also close any active UI that is on screen. Use this at a time when you wish to log a user out of your app or change a user. Once called, Intercom for iOS will no longer communicate with Intercom until a further registration is made.