### PR TITLE
Fix Countly initialization error.

### DIFF
--- a/ARAnalytics.m
+++ b/ARAnalytics.m
@@ -78,6 +78,7 @@ static BOOL _ARLogShouldPrintStdout = YES;
 
     if (analyticsDictionary[ARCountlyAppKey]) {
         // ARCountlyHost is nil if you want the cloud host.
+        // If the host URL is not nil the it should be provided without the slash at the end.
         [self setupCountlyWithAppKey:analyticsDictionary[ARCountlyAppKey] andHost:analyticsDictionary[ARCountlyHost]];
     }
 

--- a/ARAnalytics.podspec
+++ b/ARAnalytics.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name         =  'ARAnalytics'
-  s.version      =  '4.0.0'
+  s.version      =  '4.0.1'
   s.license      =  {:type => 'MIT', :file => 'LICENSE' }
   s.homepage     =  'https://github.com/orta/ARAnalytics'
   s.authors      =  { 'orta' => 'orta.therox@gmail.com', 'Daniel Haight' => "confidence.designed@gmail.com" }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Master
 
+## Version 4.0.1
+
+* Fixes Countly initialization issue
+
 ## Version 4.0.0
 
 * Fixes issue where Adjust SDK assumes event value is a string

--- a/Providers/CountlyProvider.m
+++ b/Providers/CountlyProvider.m
@@ -6,10 +6,23 @@
 - (instancetype)initWithAppKey:(NSString *)appKey andHost:(NSString *)host {
 #ifdef AR_COUNTLY_EXISTS
     NSAssert([Countly class], @"Countly is not included");
-    if (host) {
-        [[Countly sharedInstance] start:appKey withHost:host];
-    } else {
-        [[Countly sharedInstance] startOnCloudWithAppKey:appKey];
+
+    // since v16.0
+    if ([[Countly sharedInstance] respondsToSelector:@selector(startWithConfig:)]) {
+        CountlyConfig *config = [CountlyConfig new];
+        config.appKey = appKey;
+        if (host) {
+            config.host = host;
+        }
+        [[Countly sharedInstance] performSelector:@selector(startWithConfig:) withObject:config];
+    }
+    // before v16.0
+    else if ([[Countly sharedInstance] respondsToSelector:@selector(start:withHost:)]) {
+        if (host) {
+            [[Countly sharedInstance] performSelector:@selector(start:withHost:) withObject:appKey withObject:host];
+        } else {
+            [[Countly sharedInstance] performSelector:@selector(startOnCloudWithAppKey:) withObject:appKey];
+        }
     }
 #endif
 


### PR DESCRIPTION
Countly recently updated how the framework is initializated and it’s not backward compatible.

When I wanted to integrate Countly I experienced the following error:

![screen shot 2016-10-05 at 15 42 12](https://cloud.githubusercontent.com/assets/869119/19117199/7951ce58-8b18-11e6-80be-050b8ed24c9c.png)

I added a condition which determines if the project using the old or new version and initializes Countly properely.