### PR TITLE
Support for custom events tracking in HockeyApp provider

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Master
 
 * Allows AdjustProvider to be set up with an AdjustDelegate
+* Support custom event tracking for HockeyApp provider (@wzs)
 
 ## Version 4.0.1
 

--- a/Providers/HockeyAppProvider.m
+++ b/Providers/HockeyAppProvider.m
@@ -89,6 +89,9 @@ IsHockeySDKCompatibleForLogging(void)
     if (IsHockeySDKCompatibleForLogging()) {
         [self localLog:[NSString stringWithFormat:@"[%@] %@", event, properties]];
     }
+    
+    BITMetricsManager *metricsManager = [BITHockeyManager sharedHockeyManager].metricsManager;
+    [metricsManager trackEventWithName:event properties:properties measurements:nil];
 }
 
 #pragma mark - BITUpdateManagerDelegate


### PR DESCRIPTION
As HockeySDK supports custom event tracking from version [4.1.0](https://github.com/bitstadium/HockeySDK-iOS/releases/tag/4.1.0) we can use it in  `-[ARAnalyticalProvider event:withProperties:]` method.
